### PR TITLE
debug support: deal with devicestorage strictness

### DIFF
--- a/data/lib/mailapi/mailuniverse.js
+++ b/data/lib/mailapi/mailuniverse.js
@@ -774,23 +774,28 @@ MailUniverse.prototype = {
   },
 
   dumpLogToDeviceStorage: function() {
-    console.log('Planning to dump log to device storage for "pictures"');
+    console.log('Planning to dump log to device storage for "videos"');
     try {
       // 'default' does not work, but pictures does.  Hopefully gallery is
       // smart enough to stay away from my log files!
-      var storage = navigator.getDeviceStorage('pictures');
+      var storage = navigator.getDeviceStorage('videos');
+      // HACK HACK HACK: DeviceStorage does not care about our use-case at all
+      // and brutally fails to write things that do not have a mime type (and
+      // apropriately named file), so we pretend to be a realmedia file because
+      // who would really have such a thing?
       var blob = new Blob([JSON.stringify(this.createLogBacklogRep())],
                           {
-                            type: 'application/json',
+                            type: 'video/lies',
                             endings: 'transparent'
                           });
-      var filename = 'gem-log-' + Date.now() + '.json';
+      var filename = 'gem-log-' + Date.now() + '.json.rm';
       var req = storage.addNamed(blob, filename);
       req.onsuccess = function() {
         console.log('saved log to', filename);
       };
       req.onerror = function() {
-        console.error('failed to save log to', filename);
+        console.error('failed to save log to', filename, 'err:',
+                      this.error.name);
       };
     }
     catch(ex) {


### PR DESCRIPTION
DeviceStorage now only lets you write things that it thinks make sense
for its supported device storage types.  These are pictures, video, and
audio.  Unfortunately, JSON is not any of those things, so we are now
bad people and we pretend to be ".rm" files by appending ".json.rm"
instead of ".json".

r? @mozsquib 
