### PR TITLE
[ActiveSync] Only set the username from autodiscover if we actually got the username

### DIFF
--- a/data/lib/mailapi/mailuniverse.js
+++ b/data/lib/mailapi/mailuniverse.js
@@ -478,7 +478,7 @@ Configurators['activesync'] = {
       }
 
       accountDef.connInfo = { server: config.selectedServer.url };
-      if (!accountDef.identities[0].name)
+      if (!accountDef.identities[0].name && config.user)
         accountDef.identities[0].name = config.user.name;
       universe.saveAccountDef(accountDef, folderInfo);
 


### PR DESCRIPTION
r? @asutherland

This should never actually matter unless we break something else, but someone on IRC was messing about with config files and managed to get into a state where we were trying to set the user's name, even though we didn't get it from ActiveSync's autodiscovery. This additional check will save us in that case.
