### PR TITLE
Add support for a per-account synchronization range for messages

### DIFF
--- a/data/lib/mailapi/accountcommon.js
+++ b/data/lib/mailapi/accountcommon.js
@@ -102,6 +102,8 @@ CompositeAccount.prototype = {
       enabled: this.enabled,
       problems: this.problems,
 
+      syncRange: this.accountDef.syncRange,
+
       identities: this.identities,
 
       credentials: {
@@ -321,6 +323,8 @@ Configurators['imap+smtp'] = {
       receiveType: 'imap',
       sendType: 'smtp',
 
+      syncRange: '3d',
+
       credentials: credentials,
       receiveConnInfo: imapConnInfo,
       sendConnInfo: smtpConnInfo,
@@ -364,6 +368,7 @@ Configurators['fake'] = {
       name: userDetails.emailAddress,
 
       type: 'fake',
+      syncRange: '3d',
 
       credentials: credentials,
       connInfo: {
@@ -409,6 +414,7 @@ Configurators['activesync'] = {
       name: userDetails.emailAddress,
 
       type: 'activesync',
+      syncRange: '3d',
 
       credentials: credentials,
       connInfo: null,

--- a/data/lib/mailapi/activesync/account.js
+++ b/data/lib/mailapi/activesync/account.js
@@ -126,6 +126,8 @@ ActiveSyncAccount.prototype = {
       enabled: this.enabled,
       problems: this.problems,
 
+      syncRange: this.accountDef.syncRange,
+
       identities: this.identities,
 
       credentials: {

--- a/data/lib/mailapi/activesync/folder.js
+++ b/data/lib/mailapi/activesync/folder.js
@@ -29,6 +29,21 @@ define(
 
 const DESIRED_SNIPPET_LENGTH = 100;
 
+const FILTER_TYPE = $ascp.AirSync.Enums.FilterType;
+
+// Map our built-in sync range values to their corresponding ActiveSync
+// FilterType values.
+const SYNC_RANGE_TO_FILTER_TYPE = {
+   '1d': FILTER_TYPE.OneDayBack,
+   '3d': FILTER_TYPE.ThreeDaysBack,
+   '1w': FILTER_TYPE.OneWeekBack,
+   '2w': FILTER_TYPE.TwoWeeksBack,
+   '1m': FILTER_TYPE.OneMonthBack,
+   '3m': FILTER_TYPE.ThreeMonthsBack,
+   '6m': FILTER_TYPE.SixMonthsBack,
+  'all': FILTER_TYPE.NoFilter,
+};
+
 function ActiveSyncFolderConn(account, storage, _parentLog) {
   this._account = account;
   this._storage = storage;
@@ -39,9 +54,6 @@ function ActiveSyncFolderConn(account, storage, _parentLog) {
 
   if (!this.syncKey)
     this.syncKey = '0';
-  // Eventually, we should allow the user to modify this, and perhaps
-  // automatically choose a good value.
-  this.filterType = $ascp.AirSync.Enums.FilterType.OneWeekBack;
 }
 ActiveSyncFolderConn.prototype = {
   get syncKey() {
@@ -50,6 +62,18 @@ ActiveSyncFolderConn.prototype = {
 
   set syncKey(value) {
     return this.folderMeta.syncKey = value;
+  },
+
+  get filterType() {
+    let syncRange = this._account.accountDef.syncRange;
+    if (SYNC_RANGE_TO_FILTER_TYPE.hasOwnProperty(syncRange)) {
+      return SYNC_RANGE_TO_FILTER_TYPE[syncRange];
+    }
+    else {
+      console.warn('Got an invalid syncRange: ' + syncRange +
+                   ': using three days back instead');
+      return $ascp.AirSync.Enums.FilterType.ThreeDaysBack;
+    }
   },
 
   /**

--- a/data/lib/mailapi/fake/account.js
+++ b/data/lib/mailapi/fake/account.js
@@ -672,6 +672,8 @@ FakeAccount.prototype = {
       enabled: this.enabled,
       problems: this.problems,
 
+      syncRange: this.accountDef.syncRange,
+
       identities: this.identities,
 
       credentials: {

--- a/data/lib/mailapi/mailapi.js
+++ b/data/lib/mailapi/mailapi.js
@@ -18,6 +18,7 @@ function MailAccount(api, wireRep) {
   this.id = wireRep.id;
   this.type = wireRep.type;
   this.name = wireRep.name;
+  this.syncRange = wireRep.syncRange;
 
   /**
    * Is the account currently enabled, as in will we talk to the server?

--- a/data/lib/mailapi/mailbridge.js
+++ b/data/lib/mailapi/mailbridge.js
@@ -202,6 +202,10 @@ MailBridge.prototype = {
           // we expect a list of server mutation objects; namely, the type names
           // the server and the rest are attributes to change
           break;
+
+        case 'syncRange':
+          accountDef.syncRange = val;
+          break;
       }
     }
     this.universe.saveAccountDef(accountDef, null);

--- a/data/lib/mailapi/maildb.js
+++ b/data/lib/mailapi/maildb.js
@@ -31,9 +31,10 @@ else {
  *
  * Explanation of most recent bump:
  *
- * Bumping to 9 because database operations now have a deferred queue.
+ * Bumping to 10 because accounts now have a synchronization range for messages
+ * (corresponding to ActiveSync's FilterType).
  */
-const CUR_VERSION = 9;
+const CUR_VERSION = 10;
 
 /**
  * What is the lowest database version that we are capable of performing a


### PR DESCRIPTION
@asutherland: this PR adds backend support for a synchronization range and hooks the value up to ActiveSync. It doesn't do anything for IMAP yet, since I'm not 100% sure what we want it to do.

We probably want to document the meaning of the strings for `syncRange`, but I'm not sure where the best spot would be. Specifically, the format is `'all'` for all messages, and `/'\d+[dwm]'/` for N days/weeks/months back. For ActiveSync, of course, we only support values that map to the `FilterType` enum: 1d, 3d, 1w, 2d, 1m, 3m, 6m, and all.
