### PR TITLE
[imap] properly shunt login errors to probe error handler

### DIFF
--- a/data/lib/mailapi/imap/probe.js
+++ b/data/lib/mailapi/imap/probe.js
@@ -45,7 +45,11 @@ function ImapProber(credentials, connInfo, _LOG) {
 exports.ImapProber = ImapProber;
 ImapProber.prototype = {
   onLoggedIn: function ImapProber_onLoggedIn(err) {
-    if (err)
+    if (err) {
+      this.onError(err);
+      return;
+    }
+    if (!this.onresult)
       return;
 
     console.log('PROBE:IMAP happy');
@@ -54,11 +58,13 @@ ImapProber.prototype = {
     var conn = this._conn;
     this._conn = null;
 
-    if (this.onresult)
-      this.onresult(this.accountGood, conn);
+    this.onresult(this.accountGood, conn);
+    this.onresult = false;
   },
 
   onError: function ImapProber_onError(err) {
+    if (!this.onresult)
+      return;
     console.warn('PROBE:IMAP sad', err);
     this.accountGood = false;
     // we really want to make sure we clean up after this dude.
@@ -69,8 +75,7 @@ ImapProber.prototype = {
     }
     this._conn = null;
 
-    if (this.onresult)
-      this.onresult(this.accountGood, null);
+    this.onresult(this.accountGood, null);
     // we could potentially see many errors...
     this.onresult = false;
   },


### PR DESCRIPTION
@mozsquib here is the fix for https://github.com/mozilla-b2g/gaia/issues/5502

I use false rather than null when zeroing mainly so if I were to look at the state of the prober in a debugger after the fact it's clear that it was initialized at some point but we explicitly cleared it.

Note that when testing, if you are like me, you may experience paint problems where we show the error but you have to hold the home button to actually see that we showed the error 'unknown'.  We really want that to be the user/pass thing, but I'd like to do that as a follow-up.
