### PR TITLE
local search support (preliminary)

### DIFF
--- a/data/lib/mailapi/accountcommon.js
+++ b/data/lib/mailapi/accountcommon.js
@@ -163,6 +163,11 @@ CompositeAccount.prototype = {
     return this._receivePiece.sliceFolderMessages(folderId, bridgeProxy);
   },
 
+  searchFolderMessages: function(folderId, bridgeHandle, phrase, whatToSearch) {
+    return this._receivePiece.searchFolderMessages(
+      folderId, bridgeHandle, phrase, whatToSearch);
+  },
+
   syncFolderList: function(callback) {
     return this._receivePiece.syncFolderList(callback);
   },

--- a/data/lib/mailapi/activesync/account.js
+++ b/data/lib/mailapi/activesync/account.js
@@ -11,6 +11,7 @@ define(
     'activesync/protocol',
     '../a64',
     '../mailslice',
+    '../searchfilter',
     './folder',
     './jobs',
     '../util',
@@ -25,6 +26,7 @@ define(
     $activesync,
     $a64,
     $mailslice,
+    $searchfilter,
     $asfolder,
     $asjobs,
     $util,
@@ -196,6 +198,13 @@ ActiveSyncAccount.prototype = {
         slice = new $mailslice.MailSlice(bridgeHandle, storage, this._LOG);
 
     storage.sliceOpenFromNow(slice);
+  },
+
+  searchFolderMessages: function(folderId, bridgeHandle, phrase, whatToSearch) {
+    var storage = this._folderStorages[folderId],
+        slice = new $searchfilter.SearchSlice(bridgeHandle, storage, phrase,
+                                              whatToSearch, this._LOG);
+    // the slice is self-starting, we don't need to call anything on storage
   },
 
   syncFolderList: function asa_syncFolderList(callback) {

--- a/data/lib/mailapi/imap/account.js
+++ b/data/lib/mailapi/imap/account.js
@@ -9,6 +9,7 @@ define(
     '../a64',
     '../errbackoff',
     '../mailslice',
+    '../searchfilter',
     '../util',
     './folder',
     './jobs',
@@ -21,6 +22,7 @@ define(
     $a64,
     $errbackoff,
     $mailslice,
+    $searchfilter,
     $util,
     $imapfolder,
     $imapjobs,
@@ -331,6 +333,13 @@ ImapAccount.prototype = {
         slice = new $mailslice.MailSlice(bridgeHandle, storage, this._LOG);
 
     storage.sliceOpenFromNow(slice);
+  },
+
+  searchFolderMessages: function(folderId, bridgeHandle, phrase, whatToSearch) {
+    var storage = this._folderStorages[folderId],
+        slice = new $searchfilter.SearchSlice(bridgeHandle, storage, phrase,
+                                              whatToSearch, this._LOG);
+    // the slice is self-starting, we don't need to call anything on storage
   },
 
   shutdown: function() {

--- a/data/lib/mailapi/mailapi.js
+++ b/data/lib/mailapi/mailapi.js
@@ -383,6 +383,9 @@ MailHeader.prototype = {
 function MailMatchedHeader(slice, wireRep) {
   this.header = new MailHeader(slice, wireRep.header);
   this.matches = wireRep.matches;
+
+  this.element = null;
+  this.data = null;
 }
 MailMatchedHeader.prototype = {
   toString: function() {
@@ -1554,7 +1557,7 @@ MailAPI.prototype = {
    * ]
    */
   searchFolderMessages:
-      function ma_quicksearchFolderMessages(folder, text, whatToSearch) {
+      function ma_searchFolderMessages(folder, text, whatToSearch) {
     var handle = this._nextHandle++,
         slice = new BridgedViewSlice(this, 'matchedHeaders', handle);
     // the initial population counts as a request.

--- a/data/lib/mailapi/mailbridge.js
+++ b/data/lib/mailapi/mailbridge.js
@@ -93,6 +93,7 @@ function MailBridge(universe) {
     identities: [],
     folders: [],
     headers: [],
+    matchedHeaders: [],
   };
   // outstanding persistent objects that aren't slices. covers: composition
   this._pendingRequests = {};
@@ -407,11 +408,11 @@ console.log('done proc modifyConfig');
 
   _cmd_searchFolderMessages: function mb__cmd_searchFolderMessages(msg) {
     var proxy = this._slices[msg.handle] =
-          new SliceBridgeProxy(this, 'headers', msg.handle);
-    this._slicesByType['headers'].push(proxy);
-
+          new SliceBridgeProxy(this, 'matchedHeaders', msg.handle);
+    this._slicesByType['matchedHeaders'].push(proxy);
     var account = this.universe.getAccountForFolderId(msg.folderId);
-    account.searchFolderMessages(msg.folderId, proxy);
+    account.searchFolderMessages(
+      msg.folderId, proxy, msg.phrase, msg.whatToSearch);
   },
 
   _cmd_refreshHeaders: function mb__cmd_refreshHeaders(msg) {


### PR DESCRIPTION
@mozsquib This is largely just the API/skeleton of the filtering logic (test a message), so now is a great time to make any feedback you might have.  This is not remotely ready for review (although I'm hoping either late tonight or the earlier half of tomorrow.)

It's similar to the Thunderbird approach where you construct a predicate and then add that to the thing that drives the search, but it's also built so that the predicates also generate the snippet/context information.

In terms of how this is surfaced to the UI, I was figuring searches will generate a slice whose contents, rather than just being messages, are the message header and the match object.  Then we can use a specialized display item for them that prefers the matched cases for display if they exist, but falls back if not.  So if the subject or body matches, we use those snippets, but if they do not, we fall back to using the subject and body snippet like usual.

I'm not really sure as to whether to reuse the message list card directly or copy-and-paste a lot of it or try and do a mix-in/subclassing thing.
