### PR TITLE
Bug 803415 - Fix for MX lookup during autoconfig

### DIFF
--- a/data/lib/mailapi/accountcommon.js
+++ b/data/lib/mailapi/accountcommon.js
@@ -967,12 +967,23 @@ Autoconfigurator.prototype = {
       // XXX: We need to normalize the domain here to get the base domain, but
       // that's complicated because people like putting dots in TLDs. For now,
       // let's just pretend no one would do such a horrible thing.
-      mxDomain = mxDomain.split('.').slice(-2).join('.');
+      mxDomain = mxDomain.split('.').slice(-2).join('.').toLowerCase();
+      console.log('  Found MX for', mxDomain);
 
       if (domain === mxDomain)
         return callback('unknown');
 
-      self._getConfigFromDB(mxDomain, callback);
+      // If we found a different domain after MX lookup, we should look in our
+      // local file store (mostly to support Google Apps domains) and, if that
+      // doesn't work, the Mozilla ISPDB.
+      console.log('  Looking in local file store');
+      self._getConfigFromLocalFile(mxDomain, function(error, config) {
+        if (!error)
+          return callback(error, config);
+
+        console.log('  Looking in the Mozilla ISPDB');
+        self._getConfigFromDB(mxDomain, callback);
+      });
     });
   },
 
@@ -988,7 +999,7 @@ Autoconfigurator.prototype = {
   getConfig: function getConfig(userDetails, callback) {
     let [emailLocalPart, emailDomainPart] = userDetails.emailAddress.split('@');
     let domain = emailDomainPart.toLowerCase();
-    console.log('Attempting to get autoconfiguration for:'. domain);
+    console.log('Attempting to get autoconfiguration for', domain);
 
     const placeholderFields = {
       incoming: ['username', 'hostname', 'server'],


### PR DESCRIPTION
r? @asutherland

This PR fixes MX lookups, notably using lowercase for the domain we get back from MX and also trying to grab the config from the local file store first, which lets us use our special config files for Google (to make it use ActiveSync).

To make this work on Google Apps domains, just copy `apps/email/autoconfig/gmail.com` to `apps/email/autoconfig/google.com`. If you need an account on a Google Apps domain to test, I can forward you the auth details of the test account I was given.

I'll issue the PR for gaia once this is merged.
