### PR TITLE
Bug 804907 - [email] Create dialog to notify of send failure.

### DIFF
--- a/data/lib/mailapi/mailapi.js
+++ b/data/lib/mailapi/mailapi.js
@@ -1919,7 +1919,9 @@ MailAPI.prototype = {
       unexpectedBridgeDataError('Bad handle for sent:', msg.handle);
       return;
     }
-    delete this._pendingRequests[msg.handle];
+    // Only delete the request if the send succeeded.
+    if (!msg.err)
+      delete this._pendingRequests[msg.handle];
     if (req.callback) {
       req.callback.call(null, msg.err, msg.badAddresses, msg.sentDate);
       req.callback = null;


### PR DESCRIPTION
Do not clean-up the composition context unless the send succeeded.  This allows us to retry sending a message without having to complete re-create the composition context from scratch (which would be silly).

https://bugzilla.mozilla.org/show_bug.cgi?id=804907

r? @mozsquib
