### PR TITLE
Fix comment about bad sync key response

### DIFF
--- a/data/lib/mailapi/activesync/folder.js
+++ b/data/lib/mailapi/activesync/folder.js
@@ -119,8 +119,9 @@ ActiveSyncFolderConn.prototype = {
       e.run(aResponse);
 
       if (folderConn.syncKey === '0') {
-        // XXX we should re-sync the entire folder list from scratch and compute
-        // the deltas.
+        // We should never actually hit this, since it would mean that the
+        // server is refusing to give us a sync key. On the off chance that we
+        // do hit it, just bail.
         console.error('Unable to get sync key for folder');
         callback('unknown');
       }


### PR DESCRIPTION
I was looking at this comment, and realized that I was mistaken about what the code was doing. Here's a better comment.

Merging now, since it's NPOTB, but heads-up @asutherland.
