### PR TITLE
Bug 805834 - [email/IMAP][l10n] localize special folder names like INBOX, Sent, Trash, like Thunderbird does

### DIFF
--- a/data/lib/mailapi/imap/account.js
+++ b/data/lib/mailapi/imap/account.js
@@ -736,6 +736,8 @@ ImapAccount.prototype = {
           case 'INBOX':
             type = 'inbox';
             break;
+          // Yahoo provides "Bulk Mail" for yahoo.fr.
+          case 'BULK MAIL':
           case 'JUNK':
           case 'SPAM':
             type = 'junk';
@@ -745,6 +747,11 @@ ImapAccount.prototype = {
             break;
           case 'TRASH':
             type = 'trash';
+            break;
+          // This currently only exists for consistency with Thunderbird, but
+          // may become useful in the future when we need an outbox.
+          case 'UNSENT MESSAGES':
+            type = 'queue';
             break;
         }
       }

--- a/data/lib/mailapi/mailapi.js
+++ b/data/lib/mailapi/mailapi.js
@@ -159,6 +159,7 @@ function MailFolder(api, wireRep) {
    *   }
    *   @case['inbox']
    *   @case['drafts']
+   *   @case['queue']
    *   @case['sent']
    *   @case['trash']
    *   @case['archive']
@@ -2043,11 +2044,11 @@ MailAPI.prototype = {
       type: 'localizedStrings',
       strings: strings
     });
-    if(strings.folderNames)
+    if (strings.folderNames)
       this.l10n_folder_names = strings.folderNames;
   },
 
-  /*
+  /**
    * L10n strings for folder names.  These map folder types to appropriate
    * localized strings.
    *
@@ -2056,10 +2057,19 @@ MailAPI.prototype = {
   l10n_folder_names: {},
 
   l10n_folder_name: function(name, type) {
-    if(this.l10n_folder_names[type] && type === name.toLowerCase())
-      return this.l10n_folder_names[type];
-    else
-      return name;
+    if (this.l10n_folder_names.hasOwnProperty(type)) {
+      var lowerName = name.toLowerCase();
+      // Many of the names are the same as the type, but not all.
+      if ((type === lowerName) ||
+          (type === 'drafts' && lowerName === 'draft') ||
+          // yahoo.fr uses 'bulk mail' as its unlocalized name
+          (type === 'junk' && lowerName === 'bulk mail') ||
+          (type === 'junk' && lowerName === 'spam') ||
+          // this is for consistency with Thunderbird
+          (type === 'queue' && lowerName === 'unsent messages'))
+        return this.l10n_folder_names[type];
+    }
+    return name;
   },
 
   //////////////////////////////////////////////////////////////////////////////

--- a/data/lib/mailapi/mailbridge.js
+++ b/data/lib/mailapi/mailbridge.js
@@ -31,6 +31,7 @@ const FOLDER_TYPE_TO_SORT_PRIORITY = {
   inbox: 'c',
   starred: 'e',
   drafts: 'g',
+  queue: 'h',
   sent: 'i',
   junk: 'k',
   trash: 'm',


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=805834
