### PR TITLE
Bug 815379 - [email/activesync] Support usernames that aren't the email address (backend chunk)

### DIFF
--- a/data/lib/mailapi/accountcommon.js
+++ b/data/lib/mailapi/accountcommon.js
@@ -293,6 +293,7 @@ var autoconfigByDomain = exports._autoconfigByDomain = {
       // This string may be clobbered with the correct port number when
       // running as a unit test.
       server: 'http://localhost:8880',
+      username: '%EMAILADDRESS%',
     },
   },
   // Mapping for a nonexistent domain for testing a bad domain without it being
@@ -591,7 +592,7 @@ Configurators['activesync'] = {
   tryToCreateAccount: function cfg_as_ttca(universe, userDetails, domainInfo,
                                            callback, _LOG) {
     var credentials = {
-      username: userDetails.emailAddress,
+      username: domainInfo.incoming.username,
       password: userDetails.password,
     };
 
@@ -880,6 +881,7 @@ Autoconfigurator.prototype = {
         displayName: config.user.name,
         incoming: {
           server: config.mobileSyncServer.url,
+          username: config.user.email
         },
       };
       callback(null, autoconfig);


### PR DESCRIPTION
r? @asutherland. This is a tiny patch, since 99% of the backend work happened in your bug. All we need to do here is make sure the username is passed along through our functions. The interesting bit happens in the frontend (PR forthcoming) where we can manually set the username.

However, one way to test that this works in isolation is to add file as `apps/email/autoconfig/tid.es` and then use the Telefonica test account we have:

```
<clientConfig version="1.1">
  <emailProvider id="tid.es">
    <domain>tid.es</domain>
    <displayName>Telefonica Digital</displayName>
    <displayShortName>Telefonica</displayShortName>
    <incomingServer type="activesync">
      <server>https://correo.tid.es</server>
      <username>HI\%EMAILLOCALPART%</username>
    </incomingServer>
  </emailProvider>
</clientConfig>
```
