### PR TITLE
Support cancelling autoconfig

### DIFF
--- a/data/lib/mailapi/accountcommon.js
+++ b/data/lib/mailapi/accountcommon.js
@@ -757,6 +757,7 @@ Configurators['activesync'] = {
 function Autoconfigurator(_LOG) {
   this._LOG = _LOG;
   this.timeout = AUTOCONFIG_TIMEOUT_MS;
+  this._activeXHRs = [];
 }
 exports.Autoconfigurator = Autoconfigurator;
 Autoconfigurator.prototype = {
@@ -836,6 +837,14 @@ Autoconfigurator.prototype = {
     };
 
     xhr.ontimeout = xhr.onerror = function() { callback('unknown'); };
+
+    let self = this;
+    xhr.onloadend = function() {
+      let idx = self._activeXHRs.indexOf(xhr);
+      if (idx !== -1)
+        self._activeXHRs.splice(idx, 1);
+    };
+    this._activeXHRs.push(xhr);
 
     xhr.send();
   },
@@ -955,6 +964,15 @@ Autoconfigurator.prototype = {
     };
 
     xhr.ontimeout = xhr.onerror = function() { callback('unknown'); };
+
+    let self = this;
+    xhr.onloadend = function() {
+      console.log("onloadend");
+      let idx = self._activeXHRs.indexOf(xhr);
+      if (idx !== -1)
+        self._activeXHRs.splice(idx, 1);
+    };
+    this._activeXHRs.push(xhr);
 
     xhr.send();
   },
@@ -1092,6 +1110,15 @@ Autoconfigurator.prototype = {
       configurator.tryToCreateAccount(universe, userDetails, config,
                                       callback, self._LOG);
     });
+  },
+
+  /**
+   * Abort the autoconfiguration process, closing any active connections.
+   */
+  abort: function() {
+    for (let [,xhr] in Iterator(this._activeXHRs))
+      xhr.abort();
+    this._activeXHRs = [];
   },
 };
 

--- a/data/lib/mailapi/mailapi.js
+++ b/data/lib/mailapi/mailapi.js
@@ -1591,6 +1591,12 @@ MailAPI.prototype = {
     req.callback.call(null, msg.error);
   },
 
+  cancelAccountCreation: function ma_cancelAccountCreation() {
+    this.__bridgeSend({
+      type: 'cancelAccountCreation',
+    });
+  },
+
   _clearAccountProblems: function ma__clearAccountProblems(account) {
     this.__bridgeSend({
       type: 'clearAccountProblems',

--- a/data/lib/mailapi/mailbridge.js
+++ b/data/lib/mailapi/mailbridge.js
@@ -167,6 +167,10 @@ MailBridge.prototype = {
       });
   },
 
+  _cmd_cancelAccountCreation: function mb__cmd_cancelAccountCreation(msg) {
+    this.universe.cancelAccountCreation();
+  },
+
   _cmd_clearAccountProblems: function mb__cmd_clearAccountProblems(msg) {
     var account = this.universe.getAccountForAccountId(msg.accountId),
         self = this;

--- a/data/lib/mailapi/mailuniverse.js
+++ b/data/lib/mailapi/mailuniverse.js
@@ -333,6 +333,7 @@ function MailUniverse(callAfterBigBang, testOptions) {
   this._logBacklog = null;
 
   this._LOG = null;
+  this._configurator = null;
   this._db = new $maildb.MailDB(testOptions);
   this._cronSyncer = new $cronsync.CronSyncer(this);
   var self = this;
@@ -413,6 +414,7 @@ function MailUniverse(callAfterBigBang, testOptions) {
       }
     }
     self._initFromConfig();
+    self._configurator = new $acctcommon.Autoconfigurator(self._LOG);
     callAfterBigBang();
   });
 }
@@ -647,11 +649,12 @@ MailUniverse.prototype = {
                                              callback, this._LOG);
     }
     else {
-      // XXX: store configurator on this object so we can abort the connections
-      // if necessary.
-      var configurator = new $acctcommon.Autoconfigurator(this._LOG);
-      configurator.tryToCreateAccount(this, userDetails, callback);
+      this._configurator.tryToCreateAccount(this, userDetails, callback);
     }
+  },
+
+  cancelAccountCreation: function mu_cancelAccountCreation() {
+    this._configurator.abort();
   },
 
   /**


### PR DESCRIPTION
f? @asutherland: This isn't ready yet, but it does add some of the necessary plumbing to abort the autoconfig process. Notably, we're missing the ability to abort IMAP probing and ActiveSync connection negotiation. I'm not sure the best way to handle those yet...