### PR TITLE
Bug 815797 - [email/IMAP] IMAP probe error serverResponse checking assumes serverResponse is always present, breaks autoconfig in timeout case.

### DIFF
--- a/data/lib/imap.js
+++ b/data/lib/imap.js
@@ -23,6 +23,14 @@ const CHARCODE_RBRACE = ('}').charCodeAt(0),
       CHARCODE_ASTERISK = ('*').charCodeAt(0),
       CHARCODE_RPAREN = (')').charCodeAt(0);
 
+var setTimeoutFunc = window.setTimeout.bind(window),
+    clearTimeoutFunc = window.clearTimeout.bind(window);
+
+exports.TEST_useTimeoutFuncs = function(setFunc, clearFunc) {
+  setTimeoutFunc = setFunc;
+  clearTimeoutFunc = clearFunc;
+};
+
 /**
  * A buffer for us to assemble buffers so the back-end doesn't fragment them.
  * This is safe for mozTCPSocket's buffer usage because the buffer is always
@@ -247,12 +255,12 @@ ImapConnection.prototype.connect = function(loginCb) {
     this._options.host, this._options.port, socketOptions);
 
   // XXX rely on mozTCPSocket for this?
-  this._state.tmrConn = setTimeout(this._fnTmrConn.bind(this, loginCb),
-                                   this._options.connTimeout);
+  this._state.tmrConn = setTimeoutFunc(this._fnTmrConn.bind(this, loginCb),
+                                       this._options.connTimeout);
 
   this._state.conn.onopen = function(evt) {
     if (self._LOG) self._LOG.connected();
-    clearTimeout(self._state.tmrConn);
+    clearTimeoutFunc(self._state.tmrConn);
     self._state.status = STATES.NOAUTH;
     fnInit();
   };
@@ -626,7 +634,7 @@ ImapConnection.prototype.connect = function(loginCb) {
       }
 
       var sendBox = false;
-      clearTimeout(self._state.tmrKeepalive);
+      clearTimeoutFunc(self._state.tmrKeepalive);
       if (self._state.status === STATES.BOXSELECTING) {
         if (data[1] === 'OK') {
           sendBox = true;
@@ -705,7 +713,7 @@ ImapConnection.prototype.connect = function(loginCb) {
           // minutes to avoid disconnection by the server
           self._send('IDLE', null, undefined, undefined, true);
         }
-        self._state.tmrKeepalive = setTimeout(function() {
+        self._state.tmrKeepalive = setTimeoutFunc(function() {
           if (self._state.isIdle) {
             if (self._state.ext.idle.state === IDLE_READY) {
               self._state.ext.idle.timeWaited += self._state.tmoKeepalive;
@@ -747,7 +755,7 @@ ImapConnection.prototype.connect = function(loginCb) {
         if ('isNotValidAtThisTime' in err)
           err = 'bad-security';
       }
-      clearTimeout(self._state.tmrConn);
+      clearTimeoutFunc(self._state.tmrConn);
       if (self._state.status === STATES.NOCONNECT) {
         var connErr = new Error('Unable to connect. Reason: ' + err);
         connErr.type = 'unknown';
@@ -1307,8 +1315,10 @@ ImapConnection.prototype._login = function(cb) {
   }
 };
 ImapConnection.prototype._reset = function() {
-  clearTimeout(this._state.tmrKeepalive);
-  clearTimeout(this._state.tmrConn);
+  if (this._state.tmrKeepalive)
+    clearTimeoutFunc(this._state.tmrKeepalive);
+  if (this._state.tmrConn)
+    clearTimeoutFunc(this._state.tmrConn);
   this._state.status = STATES.NOCONNECT;
   this._state.numCapRecvs = 0;
   this._state.requests = [];
@@ -1369,7 +1379,7 @@ ImapConnection.prototype._send = function(cmdstr, cmddata, cb, dispatchFunc,
     var prefix = '', cmd = (bypass ? cmdstr : this._state.requests[0].command),
         data = (bypass ? null : this._state.requests[0].cmddata),
         dispatch = (bypass ? null : this._state.requests[0].dispatch);
-    clearTimeout(this._state.tmrKeepalive);
+    clearTimeoutFunc(this._state.tmrKeepalive);
     // If we are currently in IDLE, we need to exit it before we send the
     // actual command.  We mark it as a bypass so it does't mess with the
     // list of requests.

--- a/data/lib/mailapi/imap/account.js
+++ b/data/lib/mailapi/imap/account.js
@@ -590,9 +590,13 @@ ImapAccount.prototype = {
           case 'NO':
           case 'no':
             // XXX: Should we check if it's GMail first?
-            if (err.serverResponse.indexOf('[ALERT] Application-specific password required') !== -1)
+            if (!err.serverResponse)
+              errName = 'unknown';
+            else if (err.serverResponse.indexOf(
+                '[ALERT] Application-specific password required') !== -1)
               errName = 'needs-app-pass';
-            else if(err.serverResponse.indexOf('[ALERT] Your account is not enabled for IMAP use.') !== -1)
+            else if (err.serverResponse.indexOf(
+                 '[ALERT] Your account is not enabled for IMAP use.') !== -1)
               errName = 'imap-disabled';
             else
               errName = 'bad-user-or-pass';

--- a/test/unit/test_imap_errors.js
+++ b/test/unit/test_imap_errors.js
@@ -16,7 +16,7 @@
  * - Sync login failure: The server does not like our credentials.
  *
  * We test these things elsewhere:
- * -
+ * - IMAP prober issues: test_imap_prober.js
  *
  * We want tests for the following (somewhere):
  * - Sync connection loss on SELECT. (This is during the opening of the folder
@@ -31,10 +31,6 @@
  * - A non-refresh non-first synchronization (so that message display is blocked
  *    pending on the sync) fails to connect to the server and converts itself
  *    into a display of offline messages.
- *
- *
- * - Failures in the (auto)configuration process (covering all the enumerated
- *   failure values we define.)
  **/
 
 load('resources/loggest_test_framework.js');
@@ -269,6 +265,10 @@ TD.commonCase('bad password login failure', function(T) {
   T.group('use bad password');
   T.action('create connection, should fail, generate MailAPI event', eCheck,
            testAccount.eBackoff, function() {
+    // XXX uh, this bit was written speculatively to make things go faster,
+    // but FawltySocketFactory doesn't support it yet.  May just want to wait
+    // and switch to IMAP fake-server instead.
+    /*
     FawltySocketFactory.precommand(
       testHost, testPort, null,
       {
@@ -281,6 +281,7 @@ TD.commonCase('bad password login failure', function(T) {
           }
         ]
       });
+    */
 
     testAccount.eBackoff.expect_connectFailure(true);
     eCheck.expect_namedValue('accountCheck:err', true);

--- a/test/unit/test_imap_prober.js
+++ b/test/unit/test_imap_prober.js
@@ -1,0 +1,140 @@
+/**
+ * Test the IMAP prober in isolation.
+ */
+
+load('resources/loggest_test_framework.js');
+// Use the faulty socket implementation.
+load('resources/fault_injecting_socket.js');
+
+var $_imap = require('imap'),
+    $_probe = require('mailapi/imap/probe');
+
+var TD = $tc.defineTestsFor(
+  { id: 'test_imap_prober' }, null, [$th_imap.TESTHELPER], ['app']);
+
+function thunkConsole(T) {
+  var lazyConsole = T.lazyLogger('console');
+
+  gConsoleLogFunc = function(msg) {
+    lazyConsole.value(msg);
+  };
+}
+
+function thunkImapTimeouts(lazyLogger) {
+  var timeouts = [];
+  $_imap.TEST_useTimeoutFuncs(
+    function thunkedSetTimeout(func, delay) {
+      lazyLogger.namedValue('imap:setTimeout', delay);
+      return timeouts.push(func);
+    },
+    function thunkedClearTimeout() {
+      lazyLogger.event('imap:clearTimeout');
+    });
+  return function fireThunkedTimeout(index) {
+    timeouts[index]();
+    timeouts[index] = null;
+  };
+}
+
+// Currently all the tests in here are completely fake; we never connect.
+const HOST = 'localhost', PORT = 143;
+
+function makeCredsAndConnInfo() {
+  return {
+    credentials: {
+      username: 'USERNAME',
+      password: 'PASSWORD',
+    },
+    connInfo: {
+      hostname: HOST,
+      port: PORT,
+      crypto: true,
+    },
+  };
+}
+
+TD.commonCase('timeout failure', function(T, RT) {
+  thunkConsole(T);
+  var eCheck = T.lazyLogger('check'),
+      prober = null;
+
+  var fireTimeout = thunkImapTimeouts(eCheck);
+  var cci = makeCredsAndConnInfo();
+
+  T.action(eCheck, 'create prober', function() {
+    FawltySocketFactory.precommand(HOST, PORT, 'unresponsive-server');
+    eCheck.expect_namedValue('imap:setTimeout', $_probe.CONNECT_TIMEOUT_MS);
+    prober = new $_probe.ImapProber(cci.credentials, cci.connInfo,
+                                    eCheck._logger);
+    prober.onresult = function(err) {
+      eCheck.namedValue('probe result', err);
+    };
+  });
+  T.action(eCheck, 'trigger timeout', function() {
+    eCheck.expect_event('imap:clearTimeout');
+    eCheck.expect_namedValue('probe result', 'timeout');
+    fireTimeout(0);
+  });
+});
+
+const OPEN_RESPONSE =
+  '* OK [CAPABILITY IMAP4rev1 LITERAL+ SASL-IR LOGIN-REFERRALS ID ENABLE IDLE STARTTLS AUTH=PLAIN] Dovecot ready.\r\n';
+const CAPABILITY_RESPONSE = [
+  '* CAPABILITY IMAP4rev1 LITERAL+ SASL-IR LOGIN-REFERRALS ID ENABLE IDLE STARTTLS AUTH=PLAIN',
+  'A1 OK Pre-login capabilities listed, post-login capabilities have more.',
+].join('\r\n') + '\r\n';
+
+
+function cannedLoginTest(T, RT, opts) {
+  thunkConsole(T);
+  var eCheck = T.lazyLogger('check');
+
+  var fireTimeout = thunkImapTimeouts(eCheck),
+      cci = makeCredsAndConnInfo(),
+      prober;
+
+  T.action('connect, get error, return', eCheck, function() {
+    eCheck.expect_namedValue('imap:setTimeout', $_probe.CONNECT_TIMEOUT_MS);
+    eCheck.expect_event('imap:clearTimeout');
+    // imap.js doesn't really care about clearing too many times right now
+    eCheck.expect_event('imap:clearTimeout');
+    eCheck.expect_event('imap:clearTimeout');
+    eCheck.expect_event('imap:clearTimeout');
+    eCheck.expect_event('imap:clearTimeout');
+    eCheck.expect_event('imap:clearTimeout');
+    eCheck.expect_namedValue('probe result', opts.expectResult);
+    FawltySocketFactory.precommand(
+      HOST, PORT,
+      {
+        cmd: 'fake',
+        data: OPEN_RESPONSE,
+      },
+      [
+        CAPABILITY_RESPONSE,
+        'A2 ' + opts.loginErrorString + '\r\n',
+      ]);
+    prober = new $_probe.ImapProber(cci.credentials, cci.connInfo,
+                                    eCheck._logger);
+    prober.onresult = function(err) {
+      eCheck.namedValue('probe result', err);
+    };
+  });
+};
+
+TD.commonCase('gmail 2-factor auth error', function(T, RT) {
+  cannedLoginTest(T, RT, {
+    loginErrorString: 'NO [ALERT] Application-specific password required',
+    expectResult: 'needs-app-pass',
+  });
+});
+
+TD.commonCase('gmail IMAP disabled error', function(T, RT) {
+  cannedLoginTest(T, RT, {
+    loginErrorString: 'NO [ALERT] Your account is not enabled for IMAP use.',
+    expectResult: 'imap-disabled',
+  });
+});
+
+function run_test() {
+  runMyTests(15);
+}

--- a/test/unit/xpcshell.ini
+++ b/test/unit/xpcshell.ini
@@ -26,6 +26,8 @@ run-if = account == 'imap'
 run-if = account == 'imap'
 [test_imap_proto.js]
 run-if = account == 'imap'
+[test_imap_prober.js]
+run-if = account == 'imap'
 
 [test_activesync_general.js]
 run-if = account == 'activesync'


### PR DESCRIPTION
r? @mozsquib

https://bugzilla.mozilla.org/show_bug.cgi?id=815797

The unit test for the timeout-splosion fails without the patch, passes with it.

This patch also adds tests for the 2 gmail IMAP cases to the prober which is where they are most critical.
