### PR TITLE
Bug 817185 - Ensure that messages with future dates are properly retrieved from the DB

### DIFF
--- a/data/lib/mailapi/mailslice.js
+++ b/data/lib/mailapi/mailslice.js
@@ -1308,7 +1308,8 @@ FolderStorage.prototype = {
 
   /**
    * Find the first object that contains date ranges that overlaps the provided
-   * date range.  Scans from the present into the past.
+   * date range.  Scans from the present into the past.  If endTS is null, get
+   * treat it as being a date infinitely far in the future.
    */
   _findFirstObjIndexForDateRange: function ifs__findFirstObjIndexForDateRange(
       list, startTS, endTS) {
@@ -2242,10 +2243,11 @@ FolderStorage.prototype = {
    *
    * @args[
    *   @param[startTS DateMS]{
-   *     SINCE-evaluated start timestamp. (inclusive)
+   *     SINCE-evaluated start timestamp (inclusive).
    *   }
    *   @param[endTS DateMS]{
-   *     BEFORE-evaluated end timestamp. (exclusive)
+   *     BEFORE-evaluated end timestamp (exclusive).  If endTS is null, get all
+   *     messages since startTS.
    *   }
    *   @param[minDesired #:optional Number]{
    *     The minimum number of messages to return.  We will keep loading blocks

--- a/test/unit/test_folder_storage.js
+++ b/test/unit/test_folder_storage.js
@@ -1043,9 +1043,14 @@ TD.commonSimple('header iteration', function test_header_iteration() {
     chexpect(null, null, null, null));
 });
 
+/**
+ * Test that messages in the future are properly retrieved by the FolderStorage.
+ */
 TD.commonSimple('future headers', function test_future_headers() {
   var ctx = makeTestContext(),
-      dA = Date.UTC(2013, 0, 4),
+      // Ensure that our message's date is in the future (without messing with
+      // $date.NOW()).
+      dA = Date.UTC(new Date().getFullYear() + 1, 0, 4),
       uidA1 = 101, uidA2 = 102, uidA3 = 103;
 
   ctx.insertHeader(dA, uidA1);


### PR DESCRIPTION
f? @asutherland: I know you mentioned importing date.js, presumably to change the result of  `NOW()`. Should I do that to ensure a future date or something like this instead:

```
var myDate = Date.UTC(new Date().getFullYear() + 1, 0, 1);
```

https://bugzilla.mozilla.org/show_bug.cgi?id=817185
