### PR TITLE
Bug 799828 - [email] Add a missing parameter to scheduleMessagePurge

### DIFF
--- a/data/lib/mailapi/activesync/account.js
+++ b/data/lib/mailapi/activesync/account.js
@@ -698,7 +698,7 @@ ActiveSyncAccount.prototype = {
       callback();
   },
 
-  scheduleMessagePurge: function(callback) {
+  scheduleMessagePurge: function(folderId, callback) {
     // ActiveSync servers have no incremental folder growth, so message purging
     // makes no sense for them.
     if (callback)


### PR DESCRIPTION
r? @asutherland: This just add a missing param to the `scheduleMessagePurge` method for ActiveSync, to fix an error that gets thrown sometimes: https://bugzilla.mozilla.org/show_bug.cgi?id=816922#c17
