### PR TITLE
Bug 823669 - [B2G][Email]Activesync: Emails deleted on the web client do not sync to the device

### DIFF
--- a/data/lib/mailapi/activesync/folder.js
+++ b/data/lib/mailapi/activesync/folder.js
@@ -479,7 +479,7 @@ ActiveSyncFolderConn.prototype = {
         collection.push(msg);
       });
 
-      e.addEventListener(base.concat(as.Commands, [as.Delete, as.SoftDelete]),
+      e.addEventListener(base.concat(as.Commands, [[as.Delete, as.SoftDelete]]),
                          function(node) {
         let guid;
 


### PR DESCRIPTION
r? @asutherland

Pretty simple. I just forgot some square brackets. I'll work on unit tests in my unit test branch.
