### PR TITLE
Bug 824783 - [email] "No mail in this Folder" overlaps the actual emails in the sent folder if the phone times out. regression fix, a=bustage-fix

### DIFF
--- a/data/lib/mailapi/imap/folder.js
+++ b/data/lib/mailapi/imap/folder.js
@@ -145,13 +145,6 @@ function ImapFolderConn(account, storage, _parentLog) {
 }
 ImapFolderConn.prototype = {
   /**
-   * Can we grow this sync range?  IMAP always lets us do this.
-   */
-  get canGrowSync() {
-    return true;
-  },
-
-  /**
    * Acquire a connection and invoke the callback once we have it and we have
    * entered the folder.  This method should only be called when running
    * inside `runMutexed`.
@@ -830,6 +823,13 @@ ImapFolderSyncer.prototype = {
    * synchronize.  The errbackoff is just a question of when we will retry.
    */
   syncable: true,
+
+  /**
+   * Can we grow this sync range?  IMAP always lets us do this.
+   */
+  get canGrowSync() {
+    return true;
+  },
 
   syncDateRange: function(startTS, endTS, syncCallback, doneCallback,
                           progressCallback) {


### PR DESCRIPTION
A review comment was addressed, but the code put in the wrong place.
This regressed IMAP's ability to sync into the past.  This was
reflected in some of the IMAP unit tests failing.  With this correction,
the IMAP tests are all green again.

fix breakage from https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/104
