### PR TITLE
Bug 828446 - [email/IMAP] timezone offset calculation breaks if timezone offset < -7 or > 7. will result in duplicate messages.

### DIFF
--- a/data/lib/mailapi/activesync/folder.js
+++ b/data/lib/mailapi/activesync/folder.js
@@ -214,7 +214,7 @@ ActiveSyncFolderConn.prototype = {
       });
       e.addEventListener(base.concat(ie.Collection, ie.Estimate),
                          function(node) {
-        estimate = parseInt(node.children[0].textContent);
+        estimate = parseInt(node.children[0].textContent, 10);
       });
 
       try {
@@ -711,7 +711,7 @@ ActiveSyncFolderConn.prototype = {
               break;
             case asb.EstimatedDataSize:
             case em.AttSize:
-              attachment.sizeEstimate = parseInt(attachDataText);
+              attachment.sizeEstimate = parseInt(attachDataText, 10);
               break;
             case asb.ContentId:
               attachment.contentId = attachDataText;

--- a/data/lib/mailapi/imap/probe.js
+++ b/data/lib/mailapi/imap/probe.js
@@ -217,6 +217,26 @@ var normalizeError = exports.normalizeError = function normalizeError(err) {
  */
 const DEFAULT_TZ_OFFSET = -7 * 60 * 60 * 1000;
 
+var extractTZFromHeaders = exports._extractTZFromHeaders =
+    function extractTZFromHeaders(allHeaders) {
+  for (var i = 0; i < allHeaders.length; i++) {
+    var hpair = allHeaders[i];
+    if (hpair.key !== 'received')
+      continue;
+    var tzMatch = /([+-]\d{4})/.exec(hpair.value);
+    if (tzMatch) {
+      var tz =
+        parseInt(tzMatch[1].substring(1, 3), 10) * 60 * 60 * 1000 +
+        parseInt(tzMatch[1].substring(3, 5), 10) * 60 * 1000;
+      if (tzMatch[1].substring(0, 1) === '-')
+        tz *= -1;
+      return tz;
+    }
+  }
+
+  return null;
+};
+
 /**
  * Try and infer the current effective timezone of the server by grabbing the
  * most recent message as implied by UID (may be inaccurate), and then looking
@@ -265,21 +285,10 @@ var getTZOffset = exports.getTZOffset = function getTZOffset(conn, callback) {
       });
     fetcher.on('message', function onMsg(msg) {
         msg.on('end', function onMsgEnd() {
-            var allHeaders = msg.msg.headers;
-            for (var i = 0; i < allHeaders.length; i++) {
-              var hpair = allHeaders[i];
-              if (hpair.key !== 'received')
-                continue;
-              var tzMatch = /([+-]\d{4})/.exec(hpair.value);
-              if (tzMatch) {
-                var tz =
-                  parseInt(tzMatch[1].substring(1, 3)) * 60 * 60 * 1000+
-                  parseInt(tzMatch[1].substring(3, 5)) * 60 * 1000;
-                if (tzMatch[1].substring(0, 1) === '-')
-                  tz *= -1;
-                callback(null, tz);
-                return;
-              }
+            var tz = extractTZFromHeaders(msg.msg.headers);
+            if (tz !== null) {
+              callback(null, tz);
+              return;
             }
             // If we are here, the message somehow did not have a Received
             // header.  Try again with another known UID or fail out if we

--- a/data/lib/mailapi/testhelper.js
+++ b/data/lib/mailapi/testhelper.js
@@ -734,7 +734,7 @@ var TestImapAccountMixins = {
             self._logger.accountCreated();
           });
         });
-    }).timeoutMS = 5000; // there can be slow startups...
+    }).timeoutMS = 10000; // there can be slow startups...
   },
 
   /**

--- a/test/unit/test_imap_just_auth.js
+++ b/test/unit/test_imap_just_auth.js
@@ -9,5 +9,5 @@ TD.commonCase('just auth', function(T) {
 });
 
 function run_test() {
-  runMyTests(6);
+  runMyTests(15);
 }

--- a/test/unit/test_imap_prober.js
+++ b/test/unit/test_imap_prober.js
@@ -178,6 +178,34 @@ TD.commonCase('server maintenance', function(T, RT) {
   });
 });
 
+/**
+ * Test the timezone parsing logic from received headers that is used by the
+ * timezone offset calculation logic.
+ */
+TD.commonCase('timezone extraction unit', function(T, RT) {
+  thunkConsole(T);
+  var eCheck = T.lazyLogger('check');
+  var caseData = [
+    {
+      name: '2nd',
+      headers: [
+        { key: 'received',
+          value: 'from 127.0.0.1  (EHLO lists.mozilla.org) (63.245.216.66)\n' +
+            '  by mta1310.mail.gq1.yahoo.com with SMTP; ' +
+            'Wed, 09 Jan 2013 05:46:19 -0800' },
+      ],
+      tzHours: -8
+    }
+  ];
+
+  caseData.forEach(function(data) {
+    T.check(data.name, eCheck, function() {
+      eCheck.expect_namedValue('tzHours', data.tzHours);
+      var tz = $_probe._extractTZFromHeaders(data.headers);
+      eCheck.namedValue('tzHours', tz && tz / (60 * 60 * 1000));
+    });
+  });
+});
 
 function run_test() {
   runMyTests(15);


### PR DESCRIPTION
r? @mozsquib

There were a few other cases where we didn't have an explicit radix:
- the last bit of SUID's.  This is a straight-up base 10 value without padding, and there are a fair number of them.  As such, I just left them as-is (because they're not going to get an octal in there.)
- ActiveSync had two parseInts; I did modify these since I think they are always supposed to be decimal and it seems safer to hardcode us to base-10.
