### PR TITLE
Fix ActiveSync account recreation tests in light of the newish syncblocked state for fake Inboxes

### DIFF
--- a/test/unit/test_activesync_recreate.js
+++ b/test/unit/test_activesync_recreate.js
@@ -6,6 +6,7 @@
 load('resources/loggest_test_framework.js');
 const $wbxml = require('wbxml');
 const $ascp = require('activesync/codepages');
+const DEFAULT_MESSAGE_COUNT = 10;
 
 var TD = $tc.defineTestsFor(
   { id: 'test_activesync_recreate' }, null, [$th_imap.TESTHELPER], ['app']);
@@ -33,29 +34,16 @@ TD.commonCase('create, recreate offline', function(T) {
   // check that the inbox exists
   var inbox2 = TA2.do_useExistingFolderWithType('inbox', '2');
 
-  T.group('kill folder sync, go online, try and sync');
-  // Killing the folder sync means that when we go online, we don't try and sync
-  // folders and that we should expect our Inbox sync to end up claiming there
-  // are zero messages at the current time, and without error.  This is
-  // because even though we are online, we don't know the serverId for the
-  // folder and so we must do the offline sync case.
-  var savedFolderSyncOpList = T.thing('opList', 'syncFolderList');
-  TU2.do_killQueuedOperations(TA2, 'server', 1, savedFolderSyncOpList);
+  T.group('go online, try and sync');
+  // Go back online, and watch as we sync the folder.  This will require that we
+  // run syncFolderList first to turn our fake inbox into a real one.
   TU2.do_pretendToBeOffline(false);
-  var view2 = TA2.do_openFolderView(
-    'sync', inbox2, null,
-    { top: true, bottom: true, grow: true },
-    { nosave: true });
-
-  T.group('sync folder list triggers sync');
-  TU2.do_restoreQueuedOperationsAndWait(TA2, savedFolderSyncOpList, function() {
-    TA2.expect_messagesReported(inbox2.messages.length);
-    TA2.expect_headerChanges(
-      view2,
-      { additions: inbox2.messages, changes: [], deletions: [] });
-  });
-  TA2.do_closeFolderView(view2);
-
+  var view2 = TA2.do_viewFolder(
+    'sync', inbox2,
+    { count: DEFAULT_MESSAGE_COUNT,
+      full: DEFAULT_MESSAGE_COUNT, flags: 0, deleted: 0,
+      filterType: FilterType.NoFilter },
+    { top: true, bottom: true, grow: false });
 
   T.group('shutdown');
   TU2.do_saveState();
@@ -74,7 +62,6 @@ TD.commonCase('create, recreate offline', function(T) {
   var TU4 = T.actor('testUniverse', 'U4', { dbDelta: 2 }),
       TA4 = T.actor('testAccount', 'A4',
                     { universe: TU4, restored: true });
-  const DEFAULT_MESSAGE_COUNT = 10;
   var inbox4 = TA4.do_useExistingFolderWithType('inbox', '4');
   TA4.do_viewFolder('sync', inbox4,
                     { count: DEFAULT_MESSAGE_COUNT,


### PR DESCRIPTION
r? @asutherland: Here's a test-only fix for the ActiveSync account recreation tests. Adding syncblocked means that we don't need to be as clever there!
