### PR TITLE
Bug 835149 - [email/IMAP] folder list sync breaks if IMAP server (ex: courier) returns folders in non-hierarchy order.

### DIFF
--- a/data/lib/imap.js
+++ b/data/lib/imap.js
@@ -561,8 +561,9 @@ ImapConnection.prototype.connect = function(loginCb) {
               box.parent = parent;
             }
             box.displayName = decodeModifiedUtf7(name);
-            if (!curChildren[name])
-              curChildren[name] = box;
+            if (curChildren[name])
+              box.children = curChildren[name].children;
+            curChildren[name] = box;
           }
         break;
         // QRESYNC (when successful) generates a "VANISHED (EARLIER) uids"


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=835149
r? @mozsquib

Ideally I would add a unit test for this, but since old-and-busted Courier is not remotely a high priority for us, I'm thinking it might be best to just land the fix now, leave the bug open, add a bug on 'port IMAP fake-server', and have that block this bug.  Feel free to demand a unit test, though!
