### PR TITLE
Bug 833213 - [Email] Search breaks on empty subject; visible in "subject" and "all" search filters.

### DIFF
--- a/data/lib/mailapi/searchfilter.js
+++ b/data/lib/mailapi/searchfilter.js
@@ -287,8 +287,12 @@ exports.SubjectFilter = SubjectFilter;
 SubjectFilter.prototype = {
   needsBody: false,
   testMessage: function(header, body, match) {
+    const subject = header.subject;
+    // Empty subjects can't match *anything*; no empty regexes allowed, etc.
+    if (!subject)
+      return false;
     const phrase = this.phrase,
-          subject = header.subject, slen = subject.length,
+          slen = subject.length,
           stopAfter = this.stopAfter,
           contextBefore = this.contextBefore, contextAfter = this.contextAfter,
           matches = [];
@@ -481,10 +485,15 @@ MessageFilterer.prototype = {
     //            header.subject, 'body?', !!body, ')');
     var matched = false, matchObj = {};
     const filters = this.filters;
-    for (var i = 0; i < filters.length; i++) {
-      var filter = filters[i];
-      if (filter.testMessage(header, body, matchObj))
-        matched = true;
+    try {
+      for (var i = 0; i < filters.length; i++) {
+        var filter = filters[i];
+        if (filter.testMessage(header, body, matchObj))
+          matched = true;
+      }
+    }
+    catch (ex) {
+      console.error('filter exception', ex, '\n', ex.stack);
     }
     //console.log('   =>', matched, JSON.stringify(matchObj));
     if (matched)

--- a/test/unit/test_search.js
+++ b/test/unit/test_search.js
@@ -9,8 +9,17 @@ var TD = $tc.defineTestsFor(
 
 var $filters = require('mailapi/searchfilter');
 
+function thunkConsole(T) {
+  var lazyConsole = T.lazyLogger('console');
+
+  gConsoleLogFunc = function(msg) {
+    lazyConsole.value(msg);
+  };
+}
+
 TD.commonCase('author filter', function(T) {
   var eLazy = T.lazyLogger('filter');
+  thunkConsole(T);
 
   var samples = [
     { name: 'no match against empty author',
@@ -97,6 +106,7 @@ TD.commonCase('author filter', function(T) {
 
 TD.commonCase('recipient filter', function(T) {
   var eLazy = T.lazyLogger('filter');
+  thunkConsole(T);
 
   var samples = [
     { name: 'no match against empty to',
@@ -154,6 +164,7 @@ TD.commonCase('recipient filter', function(T) {
 
 TD.commonCase('subject filter', function(T) {
   var eLazy = T.lazyLogger('filter');
+  thunkConsole(T);
 
   var samples = [
     {
@@ -180,6 +191,13 @@ TD.commonCase('subject filter', function(T) {
       name: 'fail to match',
       phrase: /bob/i,
       header: { subject: 'foobar' },
+      result: false,
+      matches: []
+    },
+    {
+      name: 'do not die on null subject',
+      phrase: /bob/i,
+      header: { subject: null },
       result: false,
       matches: []
     }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=833213
r? @mozsquib
