### PR TITLE
Bug 837269 - Remove "Sent from my Firefox OS" tag line from email app.

### DIFF
--- a/data/lib/mailapi/accountcommon.js
+++ b/data/lib/mailapi/accountcommon.js
@@ -41,10 +41,6 @@ const PIECE_ACCOUNT_TYPE_TO_CLASS = {
   //'gmail-imap': GmailAccount,
 };
 
-// A boring signature that conveys the person was probably typing on a touch
-// screen, helping to explain typos and short replies.
-const DEFAULT_SIGNATURE = exports.DEFAULT_SIGNATURE =
-  'Sent from my Firefox OS device.';
 
 // The number of milliseconds to wait for various (non-ActiveSync) XHRs to
 // complete during the autoconfiguration process. This value is intentionally
@@ -461,7 +457,7 @@ Configurators['imap+smtp'] = {
           name: userDetails.displayName,
           address: userDetails.emailAddress,
           replyTo: null,
-          signature: DEFAULT_SIGNATURE
+          signature: null
         },
       ],
       tzOffset: tzOffset,
@@ -524,7 +520,7 @@ Configurators['fake'] = {
           name: userDetails.displayName,
           address: userDetails.emailAddress,
           replyTo: null,
-          signature: DEFAULT_SIGNATURE
+          signature: null
         },
       ]
     };
@@ -646,7 +642,7 @@ Configurators['activesync'] = {
             name: userDetails.displayName || domainInfo.displayName,
             address: userDetails.emailAddress,
             replyTo: null,
-            signature: DEFAULT_SIGNATURE
+            signature: null
           },
         ]
       };

--- a/test/unit/test_compose.js
+++ b/test/unit/test_compose.js
@@ -152,7 +152,10 @@ TD.commonCase('compose, reply (text/plain), forward', function(T, RT) {
           '> Antelope banana credenza.',
           '>',
           '> Dialog excitement!',
-          '', '-- ', $_accountcommon.DEFAULT_SIGNATURE, '',
+          // XXX we used to have a default signature; when we start letting
+          // users configure signatures again, then we will want the test to
+          // use one and put this back.
+          //'', '-- ', $_accountcommon.DEFAULT_SIGNATURE, '',
         ].join('\n'),
         html: null
       };
@@ -211,7 +214,8 @@ TD.commonCase('compose, reply (text/plain), forward', function(T, RT) {
       expectedForwardBody = {
         text: [
           '', '',
-          '-- ', $_accountcommon.DEFAULT_SIGNATURE, '',
+          // XXX when signatures get enabled/tested:
+          // '-- ', $_accountcommon.DEFAULT_SIGNATURE, '',
           '-------- Original Message --------',
           'Subject: Re: ' + uniqueSubject,
           'Date: ' + safeifyTime(replySentDate + ''),
@@ -285,10 +289,12 @@ TD.commonCase('reply/forward html message', function(T, RT) {
         '</style>' +
         '<p>I am the reply to the quote below.</p>' +
         '<blockquote><p>I am the replied-to text!</p></blockquote>' +
-        '</blockquote>' +
+        '</blockquote>',
+        /* XXX when signatures get put back in/tested:
         '<pre class="moz-signature" cols="72">' +
         $_accountcommon.DEFAULT_SIGNATURE +
         '</pre>',
+        */
       bpartHtml =
         new SyntheticPartLeaf(
           bstrHtml,  { contentType: 'text/html' });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=837269
r? @mozsquib

This patch removes the default entirely and updates the compose unit tests to assume there is no signature present by commenting out those bits.  We will obviously want some test coverage of signatures in the future, which is why I commented those bits out rather than nuking entirely.

This does not rev the database or otherwise attempt to clean up existing signatures; I'll ask on the bug about that.
