### PR TITLE
Bug 838009 - support sdcard storage for saving all types of attachments, r=asutherland

### DIFF
--- a/data/lib/mailapi/jobmixins.js
+++ b/data/lib/mailapi/jobmixins.js
@@ -236,8 +236,8 @@ exports.do_download = function(op, callback) {
       if (partInfo.file)
         continue;
       partsToDownload.push(partInfo);
-      // right now all attachments go in pictures
-      storePartsTo.push('pictures');
+      // right now all attachments go in sdcard
+      storePartsTo.push('sdcard');
     }
 
     folderConn.downloadMessageAttachments(uid, partsToDownload, gotParts);


### PR DESCRIPTION
Since we need to support images, audio and videos for saving attachments in v1.1, we should use sdcard storage for all these types, and in future, I believe we are going to support the other types like pdf or txt, so use sdcard storage should be a good choice.
