### PR TITLE
Bug 822882 - Initial bisect sync fix try #2.

### DIFF
--- a/data/lib/mailapi/date.js
+++ b/data/lib/mailapi/date.js
@@ -195,7 +195,7 @@ var makeDaysAgo = exports.makeDaysAgo =
 var makeDaysBefore = exports.makeDaysBefore =
       function makeDaysBefore(date, numDaysBefore) {
   if (date === null)
-    return makeDaysAgo(numDaysBefore);
+    return makeDaysAgo(numDaysBefore - 1);
   return quantizeDate(date) - numDaysBefore * DAY_MILLIS;
 };
 /**


### PR DESCRIPTION
makeDaysBefore's use of makeDaysAgo was foolish since it caused unexpected
rounding up.  Because of the various deadlines and pressures, I'm sort of
running around with my head cut off, so this wasn't a tremendously surprising
oversight.

This includes a timezone stopgap fix; I'm probably going to have to implement
the IMAP fake server soon for other horrible things that are going on, which
should eliminate the need for this hack.
