### PR TITLE
Bug 853602 - [email/activesync] GetItemEstimate fails for older versions of Exchange

### DIFF
--- a/data/lib/mailapi/activesync/folder.js
+++ b/data/lib/mailapi/activesync/folder.js
@@ -227,15 +227,30 @@ ActiveSyncFolderConn.prototype = {
     var w = new $wbxml.Writer('1.3', 1, 'UTF-8');
     w.stag(ie.GetItemEstimate)
        .stag(ie.Collections)
-         .stag(ie.Collection)
-           .tag(as.SyncKey, this.syncKey)
+         .stag(ie.Collection);
+
+    if (this._account.conn.currentVersion.gte('14.0')) {
+          w.tag(as.SyncKey, this.syncKey)
            .tag(ie.CollectionId, this.serverId)
            .stag(as.Options)
              .tag(as.FilterType, filterType)
-           .etag()
-         .etag()
-       .etag()
-     .etag();
+           .etag();
+    }
+    else if (this._account.conn.currentVersion.gte('12.0')) {
+          w.tag(ie.CollectionId, this.serverId)
+           .tag(as.FilterType, filterType)
+           .tag(as.SyncKey, this.syncKey);
+    }
+    else {
+          w.tag(ie.Class, 'Email')
+           .tag(ie.CollectionId, this.serverId)
+           .tag(as.SyncKey, this.syncKey)
+           .tag(as.FilterType, filterType);
+    }
+
+        w.etag(ie.Collection)
+       .etag(ie.Collections)
+     .etag(ie.GetItemEstimate);
 
     this._account.conn.postCommand(w, function(aError, aResponse) {
       if (aError) {


### PR DESCRIPTION
r? @asutherland: This is straightforward and only an issue for compatibility with older servers. The tag structure was taken from the Android code.

https://bugzilla.mozilla.org/show_bug.cgi?id=853602
