### PR TITLE
Bug 853908 email: point where to find codepages parts not in protocol

### DIFF
--- a/scripts/end.js
+++ b/scripts/end.js
@@ -12,6 +12,26 @@ require.config({
     'activesync/codepages': 'js/ext/mailapi/activesync/protocollayer',
     'activesync/protocol': 'js/ext/mailapi/activesync/protocollayer',
 
+    // activesync/codepages is split across two layers. If
+    // activesync/protocol loads first (for autoconfig work on account setup),
+    // then indicate the parts of codepages that are in activesync/configurator
+    'activesync/codepages/FolderHierarchy':
+                                      'js/ext/mailapi/activesync/configurator',
+    'activesync/codepages/ComposeMail':
+                                      'js/ext/mailapi/activesync/configurator',
+    'activesync/codepages/AirSync':
+                                      'js/ext/mailapi/activesync/configurator',
+    'activesync/codepages/AirSyncBase':
+                                      'js/ext/mailapi/activesync/configurator',
+    'activesync/codepages/ItemEstimate':
+                                      'js/ext/mailapi/activesync/configurator',
+    'activesync/codepages/Email':
+                                      'js/ext/mailapi/activesync/configurator',
+    'activesync/codepages/ItemOperations':
+                                      'js/ext/mailapi/activesync/configurator',
+    'activesync/codepages/Move':
+                                      'js/ext/mailapi/activesync/configurator',
+
     // Point chew methods to the chew layer
     'mailapi/htmlchew': 'js/ext/mailapi/chewlayer',
     'mailapi/quotechew': 'js/ext/mailapi/chewlayer',


### PR DESCRIPTION
activesync/codepages is split across two build layers, as part of the change for [852710](https://bugzilla.mozilla.org/show_bug.cgi?id=852710). However, for account setup where there is not an autoconfig match, activesync/protocol is loaded by itself in accountcommon.js. Since the layer that has activesync/protocol does not have all of activesync/codepagse in it, the location of the other parts of activesync/codepages needs to be configured. This patch addresses that issue.

Tested on a non-autoconfig account, and code scanned for any other activesync side loading. This was the only one that was missed as part of 852710.
