### PR TITLE
Bug 854097 - [email/IMAP] Saving sent mail to 'sent' folder on servers that don't support MULTIAPPEND regressed by bug 814257. r=asuth

### DIFF
--- a/data/lib/imap.js
+++ b/data/lib/imap.js
@@ -993,7 +993,7 @@ ImapConnection.prototype.append = function(data, options, cb) {
     if (err || step++ === 2)
       return cb(err);
     if (typeof(data) === 'string') {
-      self._state.conn.send(Buffer(data + CRLF));
+      self._state.conn.write(Buffer(data + CRLF));
     }
     else {
       self._state.conn.write(data);


### PR DESCRIPTION
https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/122 missed a .send => .write

As noted on https://bugzilla.mozilla.org/show_bug.cgi?id=854097 our unit tests didn't see this because the test server we normally runs against supports MULTIAPPEND.

This is very straightforward and an oversight in my original review.  This ideally would have a unit test, but the probability of this specifically regressing again is extremely low.
