### PR TITLE
[activesync] Fix body observers test

### DIFF
--- a/test/unit/test_body_observers.js
+++ b/test/unit/test_body_observers.js
@@ -1,14 +1,12 @@
 define(['rdcommon/testcontext', 'mailapi/testhelper',
+        './resources/th_activesync_server',
         'activesync/codepages', 'exports'],
-       function($tc, $th_imap, $ascp, exports) {
+       function($tc, $th_imap, $th_as_server, $ascp, exports) {
 var FilterType = $ascp.AirSync.Enums.FilterType;
 
 var TD = exports.TD = $tc.defineTestsFor(
-  { id: 'test_body_observers' },
-  null,
-  [$th_imap.TESTHELPER],
-  ['app']
-);
+  { id: 'test_body_observers' }, null,
+  [$th_imap.TESTHELPER, $th_as_server.TESTHELPER], ['app']);
 
 TD.commonCase('body update events', function(T, RT) {
   var testUniverse = T.actor('testUniverse', 'U', { realDate: true }),


### PR DESCRIPTION
r? @asutherland: Another simple fix. I think this file got added while I was fixing up the ActiveSync tests after the worker thread landing, and so I missed it.
