### PR TITLE
Bug 837836: related commit that removes dynamic loader for front end code

### DIFF
--- a/deps/amd-shim.js
+++ b/deps/amd-shim.js
@@ -1,0 +1,27 @@
+var define;
+(function () {
+  var modules = {};
+  define = function (id, deps, fn) {
+    if (typeof deps === 'function') {
+        fn = deps;
+        deps = null;
+    }
+
+    if (deps) {
+      deps = deps.map(function (dep) {
+        if (dep.charAt(0) === '.') {
+          dep = 'mailapi' + dep.substring(1);
+        }
+        if (dep === 'exports') {
+          return modules[id] = {};
+        } else {
+          return modules[dep];
+        }
+      });
+    }
+    var result = fn.apply(modules[id], deps);
+    if (!modules[id]) {
+      modules[id] = result;
+    }
+  };
+}());

--- a/scripts/copy-to-gaia.js
+++ b/scripts/copy-to-gaia.js
@@ -24,6 +24,7 @@ buildOptions = {
   useStrict: true,
   paths: {
     'alameda': 'deps/alameda',
+    'amd-shim': 'deps/amd-shim',
     'config': 'scripts/config',
 
     // NOP's
@@ -95,8 +96,8 @@ var configs = [
 
   // root aggregate loaded in main frame context
   {
-    name: 'mailapi/main-frame-setup',
-    include: [],
+    name: null,
+    include: ['amd-shim', 'mailapi/main-frame-setup'],
     out: jsPath + '/mailapi/main-frame-setup.js'
   },
 
@@ -247,22 +248,15 @@ var runner = configs.reduceRight(function (prev, cfg) {
 
     // List of tags used in gaia
     var indexPaths = [
-      'alameda',
       'end'
     ];
 
     // Copy some bootstrap scripts over to gaia
-    fs.writeFileSync(path.join(jsPath, 'alameda.js'),
-      fs.readFileSync(path.join(__dirname, '..', 'deps', 'alameda.js')),
-      'utf8');
     fs.writeFileSync(endPath,
       fs.readFileSync(path.join(__dirname, 'end.js')),
       'utf8');
 
-    // Modify end.js to include config.js
-    var configContents = fs.readFileSync(path.join(__dirname, 'config.js'),
-                                         'utf8');
-    fs.writeFile(endPath, configContents + fs.readFileSync(endPath, 'utf8'));
+    fs.writeFile(endPath, fs.readFileSync(endPath, 'utf8'), 'utf8');
 
     // Update gaia email index.html with the right script tags.
     scriptText = startComment + '\n' +

--- a/scripts/end.js
+++ b/scripts/end.js
@@ -1,10 +1,3 @@
-// config.js will be injected above this comment
-
-// baseUrl is different for front end
-require.config({
-  baseUrl: 'js/ext'
-});
-
 (function () {
   // Send fake API object to allow UI to finish bootstrapping, and finish
   // back-end loading when viewAccounts is called.
@@ -27,7 +20,7 @@ require.config({
           if (acctSlice.oncomplete) {
               acctSlice.oncomplete();
           }
-          require(['mailapi/main-frame-setup']);
+          App.loader.load(['js/ext/mailapi/main-frame-setup.js']);
       }, 0);
       return acctSlice;
     }


### PR DESCRIPTION
Remove dynamic loading for front end, since dynamic loading is only in the worker for back end. Will be part of the 837836 lazy DOM gaia pull request. Combining them for expediency and ease of uplift.
