### PR TITLE
Bug 852003 - [email] ActiveSync mimetype-guessing fails for files with non-lowercase extensions (e.g. foo.PNG)

### DIFF
--- a/data/lib/mailapi/activesync/folder.js
+++ b/data/lib/mailapi/activesync/folder.js
@@ -767,7 +767,8 @@ ActiveSyncFolderConn.prototype = {
               // Get the file's extension to look up a mimetype, but ignore it
               // if the filename is of the form '.bashrc'.
               dot = attachment.name.lastIndexOf('.');
-              ext = dot > 0 ? attachment.name.substring(dot + 1) : '';
+              ext = dot > 0 ? attachment.name.substring(dot + 1).toLowerCase() :
+                              '';
               attachment.type = $mimelib.contentTypes[ext] ||
                                 'application/octet-stream';
               break;


### PR DESCRIPTION
r? @asutherland: This is a really simple fix that I've confirmed works in the email app. Not much else to say here. No tests, though I could add some.

https://bugzilla.mozilla.org/show_bug.cgi?id=852003
