### PR TITLE
Bug 869817 - [Email] Last Sync: value at folder screen is not displayed properly with IMAP accounts

### DIFF
--- a/data/lib/mailapi/mailslice.js
+++ b/data/lib/mailapi/mailslice.js
@@ -3327,7 +3327,9 @@ FolderStorage.prototype = {
 
     aranges.splice.apply(aranges, [newInfo[0], delCount].concat(insertions));
 
-    this.folderMeta.lastSyncedAt = endTS;
+    /*lastSyncedAt depends on current timestamp of the client device
+     should not be added timezone offset*/
+    this.folderMeta.lastSyncedAt = NOW();
     if (this._account.universe)
       this._account.universe.__notifyModifiedFolder(this._account,
                                                     this.folderMeta);


### PR DESCRIPTION
lastSyncedAt is assigned with NOW() as endTS is used along with TimeZone offset.

Please review it.
