### PR TITLE
Bug 879511 - [email/IMAP] date-time parsing regex does not accept legal "SP DIGIT" syntax

### DIFF
--- a/data/lib/imap.js
+++ b/data/lib/imap.js
@@ -18,8 +18,10 @@ var emptyFn = function() {}, CRLF = '\r\n',
     reFetch = /^\* (\d+) FETCH [\s\S]+? \{(\d+)\}$/,
     reUid = /UID (\d+)/,
     reBodyPart = /BODY/,
-    reDate = /^(\d{2})-(.{3})-(\d{4})$/,
-    reDateTime = /^(\d{2})-(.{3})-(\d{4}) (\d{2}):(\d{2}):(\d{2}) ([+-]\d{4})$/,
+    // ( ?\d|\d{2}) = day number; technically it's either "SP DIGIT" or "2DIGIT"
+    // but there's no harm in us accepting a single digit without whitespace;
+    // it's conceivable the caller might have trimmed whitespace.
+    reDateTime = /^( ?\d|\d{2})-(.{3})-(\d{4}) (\d{2}):(\d{2}):(\d{2}) ([+-]\d{4})$/,
     HOUR_MILLIS = 60 * 60 * 1000, MINUTE_MILLIS = 60 * 1000;
 
 const CHARCODE_RBRACE = ('}').charCodeAt(0),
@@ -43,19 +45,6 @@ var gSendBuf = new Uint8Array(2000);
 
 function singleArgParseInt(x) {
   return parseInt(x, 10);
-}
-
-/**
- * Parses (UTC) IMAP dates into UTC timestamps. IMAP dates are DD-Mon-YYYY.
- */
-function parseImapDate(dstr) {
-  var match = reDate.exec(dstr);
-  if (!match)
-    throw new Error("Not a good IMAP date: " + dstr);
-  var day = parseInt(match[1], 10),
-      zeroMonth = MONTHS.indexOf(match[2]),
-      year = parseInt(match[3], 10);
-  return Date.UTC(year, zeroMonth, day);
 }
 
 /**
@@ -94,8 +83,23 @@ function decodeModifiedUtf7(encoded) {
 exports.decodeModifiedUtf7 = decodeModifiedUtf7;
 
 /**
- * Parses IMAP date-times into UTC timestamps.  IMAP date-times are
- * "DD-Mon-YYYY HH:MM:SS +ZZZZ"
+ * Parses IMAP "date-time" instances into UTC timestamps whose quotes have
+ * already been stripped.
+ *
+ * http://tools.ietf.org/html/rfc3501#page-84
+ *
+ * date-day        = 1*2DIGIT
+ *                    ; Day of month
+ * date-day-fixed  = (SP DIGIT) / 2DIGIT
+ *                    ; Fixed-format version of date-day
+ * date-month      = "Jan" / "Feb" / "Mar" / "Apr" / "May" / "Jun" /
+ *                   "Jul" / "Aug" / "Sep" / "Oct" / "Nov" / "Dec"
+ * date-year       = 4DIGIT
+ * time            = 2DIGIT ":" 2DIGIT ":" 2DIGIT
+ *                     ; Hours minutes seconds
+ * zone            = ("+" / "-") 4DIGIT
+ * date-time       = DQUOTE date-day-fixed "-" date-month "-" date-year
+ *                   SP time SP zone DQUOTE
  */
 function parseImapDateTime(dstr) {
   var match = reDateTime.exec(dstr);
@@ -122,6 +126,7 @@ function parseImapDateTime(dstr) {
 
   return timestamp;
 }
+exports.parseImapDateTime = parseImapDateTime;
 
 function formatImapDateTime(date) {
   var s;

--- a/test/unit/test_imap_proto.js
+++ b/test/unit/test_imap_proto.js
@@ -3,14 +3,14 @@
  * the modified utf-7 decoding test.
  */
 
-define(['rdcommon/testcontext', './resources/th_main', 'exports'],
-       function($tc, $th_imap, exports) {
+define(['rdcommon/testcontext', './resources/th_main', 'imap', 'exports'],
+       function($tc, $th_imap, $imap, exports) {
 
 var TD = exports.TD = $tc.defineTestsFor(
   { id: 'test_imap_proto' }, null, [$th_imap.TESTHELPER], ['app']);
 
 TD.commonSimple('decodeModifiedUtf7', function(lazy) {
-  var decodeModifiedUtf7 = require('imap').decodeModifiedUtf7;
+  var decodeModifiedUtf7 = $imap.decodeModifiedUtf7;
 
   function check(encoded, expected) {
     lazy.expect_namedValue(encoded, expected);
@@ -25,6 +25,29 @@ TD.commonSimple('decodeModifiedUtf7', function(lazy) {
   // from RFC3501
   check('~peter/mail/&U,BTFw-/&ZeVnLIqe-',
         '~peter/mail/\u53f0\u5317/\u65e5\u672c\u8a9e');
+});
+
+TD.commonSimple('parseImapDateTime', function(lazy) {
+  function check(str, expectedTimestamp) {
+    var parsedTS = $imap.parseImapDateTime(str);
+
+    lazy.expect_namedValue(str, expectedTimestamp);
+    lazy.namedValue(str, parsedTS);
+  }
+
+  // remember! dates are zero-based!
+
+  // handle "space digit" for day number
+  check(' 4-Jun-2013 14:15:49 -0500',
+        Date.UTC(2013, 5, 4, 19, 15, 49));
+  // handle "digit" for day number (we may get trimmed)
+  check('4-Jun-2013 14:15:49 -0500',
+        Date.UTC(2013, 5, 4, 19, 15, 49));
+  // handle digit digit
+  check('04-Jun-2013 14:15:49 -0500',
+        Date.UTC(2013, 5, 4, 19, 15, 49));
+  check('14-Jun-2013 14:15:49 -0500',
+        Date.UTC(2013, 5, 14, 19, 15, 49));
 });
 
 }); // end define


### PR DESCRIPTION
also removes speculative parseImapDate logic function that is not used.
