### PR TITLE
have install-into-gaia trigger the clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ $(DEP_NODE_PKGS): $(TRANS_NODE_PKGS)
 
 OUR_JS_DEPS := $(wildcard data/lib/mailapi/*.js) $(wildcard data/lib/mailapi/imap/*.js) $(wildcard data/lib/mailapi/smtp*.js) $(wildcard data/lib/mailapi/activesync/*.js) $(wildcard data/deps/rdcommon/*.js)
 
-install-into-gaia: gaia-symlink $(DEP_NODE_PKGS) $(OUR_JS_DEPS)
+install-into-gaia: clean gaia-symlink $(DEP_NODE_PKGS) $(OUR_JS_DEPS)
 	node scripts/copy-to-gaia.js gaia-symlink/apps/email
 
 build: $(DEP_NODE_PKGS) $(OUR_JS_DEPS)


### PR DESCRIPTION
It's very possible to get a stale dependency in install-into-gaia. While it
does make us a smidge slower, we should do this until we can have ironclad
dependencies so we never screw up.

r? @lightsofapollo 
