### PR TITLE
Bug 860262 - [Email] When selecting the option “replying to all” or “rep...

### DIFF
--- a/data/lib/mailapi/mailbridge.js
+++ b/data/lib/mailapi/mailbridge.js
@@ -869,7 +869,8 @@ MailBridge.prototype = {
             handle: msg.handle,
             error: null,
             identity: identity,
-            subject: 'Fwd: ' + msg.refSubject,
+            subject: $composer.mailchew
+                       .generateForwardSubject(msg.refSubject),
             // blank lines at the top are baked in by the func
             body: $composer.mailchew.generateForwardMessage(
                     msg.refAuthor, msg.refDate, msg.refSubject,

--- a/data/lib/mailapi/mailchew.js
+++ b/data/lib/mailapi/mailchew.js
@@ -30,7 +30,7 @@ define(
 
 var DESIRED_SNIPPET_LENGTH = 100;
 
-var RE_RE = /^[Rr][Ee]: /;
+var RE_RE = /^[Rr][Ee]:/;
 
 /**
  * Generate the reply subject for a message given the prior subject.  This is
@@ -55,10 +55,34 @@ var RE_RE = /^[Rr][Ee]: /;
  * http://mxr.mozilla.org/comm-central/ident?i=NS_MsgStripRE for more details.
  */
 exports.generateReplySubject = function generateReplySubject(origSubject) {
-  if (RE_RE.test(origSubject))
+  var re = 'Re: ';
+  if (origSubject) {
+    if (RE_RE.test(origSubject))
       return origSubject;
-  return 'Re: ' + origSubject;
+
+    return re + origSubject;
+  }
+  return re;
 };
+
+var FWD_FWD = /^[Ff][Ww][Dd]:/;
+
+/**
+ * Generate the foward subject for a message given the prior subject.  This is
+ * simply prepending "Fwd: " to the message if it does not already have an
+ * "Fwd:" equivalent.
+ */
+exports.generateForwardSubject = function generateForwardSubject(origSubject) {
+  var fwd = 'Fwd: ';
+  if (origSubject) {
+    if (FWD_FWD.test(origSubject))
+      return origSubject;
+
+    return fwd + origSubject;
+  }
+  return fwd;
+};
+
 
 var l10n_wroteString = '{name} wrote',
     l10n_originalMessageString = 'Original Message';
@@ -82,7 +106,7 @@ var l10n_forward_header_labels = {
   from: 'From',
   replyTo: 'Reply-To',
   to: 'To',
-  cc: 'CC',
+  cc: 'CC'
 };
 
 exports.setLocalizedStrings = function(strings) {
@@ -97,7 +121,7 @@ exports.setLocalizedStrings = function(strings) {
 if ($mailchewStrings.strings) {
   exports.setLocalizedStrings($mailchewStrings.strings);
 }
-$mailchewStrings.events.on('strings', function (strings) {
+$mailchewStrings.events.on('strings', function(strings) {
   exports.setLocalizedStrings(strings);
 });
 
@@ -171,7 +195,7 @@ exports.generateReplyBody = function generateReplyMessage(reps, authorPair,
  * Generate the body of an inline forward message.  XXX we need to generate
  * the header summary which needs some localized strings.
  */
-exports.generateForwardMessage = 
+exports.generateForwardMessage =
   function(author, date, subject, headerInfo, bodyInfo, identity) {
 
   var textMsg = '\n\n', htmlMsg = null;

--- a/test/unit/test_mail_quoting.js
+++ b/test/unit/test_mail_quoting.js
@@ -6,8 +6,8 @@
  **/
 
 define(['rdcommon/testcontext', './resources/th_main',
-        'mailapi/quotechew', 'exports'],
-       function($tc, $th_imap, $quotechew, exports) {
+        'mailapi/quotechew', 'mailapi/mailchew', 'exports'],
+       function($tc, $th_imap, $quotechew, $mailchew, exports) {
 
 var TD = exports.TD = $tc.defineTestsFor(
   { id: 'test_mail_quoting' }, null, [$th_imap.TESTHELPER], ['app']);
@@ -436,6 +436,45 @@ TD.commonCase('Quoting', function(T) {
       eCheck.event('done');
     });
   });
+});
+
+TD.commonSimple('Empty subject reply', function(eLazy) {
+  var scenarios = [
+    [null, 'Re: '],
+    ['', 'Re: '],
+    ['RE:', 'RE:'],
+    ['test', 'Re: test'],
+    ['Re: test', 'Re: test']
+  ];
+
+  for (i = 0; i < scenarios.length; i++) {
+    scenario = scenarios[i];
+    eLazy.expect_namedValue(scenario[0], scenario[1]);
+  }
+  for (i = 0; i < scenarios.length; i++) {
+    scenario = scenarios[i];
+    eLazy.namedValue(scenario[0], $mailchew.generateReplySubject(scenario[0]));
+  }
+});
+
+TD.commonSimple('Empty forward reply', function(eLazy) {
+  var scenarios = [
+    [null, 'Fwd: '],
+    ['', 'Fwd: '],
+    ['FWD:', 'FWD:'],
+    ['test', 'Fwd: test'],
+    ['Fwd: test', 'Fwd: test']
+  ];
+
+  for (i = 0; i < scenarios.length; i++) {
+    scenario = scenarios[i];
+    eLazy.expect_namedValue(scenario[0], scenario[1]);
+  }
+  for (i = 0; i < scenarios.length; i++) {
+    scenario = scenarios[i];
+    eLazy.namedValue(scenario[0],
+      $mailchew.generateForwardSubject(scenario[0]));
+  }
 });
 
 }); // end define


### PR DESCRIPTION
...ly” or “forward” on an email that was previously sent without Subject, the new Subject is shown as: “Re:null” or “Fwd:null”
