### PR TITLE
Bug 899005 - [Email] We have time zone issue when we run the unit tests for gaia-email-libs-and-more

### DIFF
--- a/test-runner/chrome/fakeserver/subscript/imapd.js
+++ b/test-runner/chrome/fakeserver/subscript/imapd.js
@@ -1725,7 +1725,7 @@ IMAP_RFC3501_handler.prototype = {
   },
   _FETCH_INTERNALDATE : function (message) {
     var response = "INTERNALDATE \"";
-    response += message.date.toLocaleFormat("%d-%b-%Y %H:%M:%S %z");
+    response += formatImapDateTime(message.date);
     response += "\"";
     return response;
   },


### PR DESCRIPTION
Use the formatImapDateTime function to skip the time zone issue.
http://bugzil.la/899005
