### PR TITLE
Bug 887700 - [OTA] [Data Migration] [Email] Cannot load email in Inbox after update from v1.0.1 to v1.1.0

### DIFF
--- a/data/lib/mailapi/mailapi.js
+++ b/data/lib/mailapi/mailapi.js
@@ -525,7 +525,7 @@ var ContactCache = exports.ContactCache = {
   },
 
   resolvePeeps: function(addressPairs) {
-    if (addressPairs === null)
+    if (addressPairs == null)
       return null;
     var resolved = [];
     for (var i = 0; i < addressPairs.length; i++) {


### PR DESCRIPTION
After OTA updated, do an early return while the address pairs is null.
