### PR TITLE
Bug 892519 - [email] Notifications - Email App Not Foreground

### DIFF
--- a/data/lib/evt.js
+++ b/data/lib/evt.js
@@ -1,0 +1,162 @@
+// COPIED FROM gaia/apps/emailjs/evt.js
+/*global define, setTimeout */
+/*
+ * Custom events lib. Notable features:
+ *
+ * - the module itself is an event emitter. Useful for "global" pub/sub.
+ * - evt.mix can be used to mix in an event emitter into existing object.
+ * - notification of listeners is done in a try/catch, so all listeners
+ *   are notified even if one fails. Errors are thrown async via setTimeout
+ *   so that all the listeners can be notified without escaping from the
+ *   code via a throw within the listener group notification.
+ * - new evt.Emitter() can be used to create a new instance of an
+ *   event emitter.
+ * - Uses "this" insternally, so always call object with the emitter args
+ *
+ */
+define(function() {
+
+  var evt,
+      slice = Array.prototype.slice,
+      props = ['_events', '_pendingEvents', 'on', 'once', 'latest',
+               'latestOnce', 'removeListener', 'emitWhenListener', 'emit'];
+
+  function Emitter() {
+    this._events = {};
+    this._pendingEvents = {};
+  }
+
+  Emitter.prototype = {
+    on: function(id, fn) {
+      var listeners = this._events[id],
+          pending = this._pendingEvents[id];
+      if (!listeners) {
+        listeners = this._events[id] = [];
+      }
+      listeners.push(fn);
+
+      if (pending) {
+        pending.forEach(function(args) {
+          fn.apply(null, args);
+        });
+        delete this._pendingEvents[id];
+      }
+      return this;
+    },
+
+    once: function(id, fn) {
+      var self = this,
+          fired = false;
+      function one() {
+        if (fired)
+          return;
+        fired = true;
+        fn.apply(null, arguments);
+        // Remove at a further turn so that the event
+        // forEach in emit does not get modified during
+        // this turn.
+        setTimeout(function() {
+          self.removeListener(id, one);
+        });
+      }
+      return this.on(id, one);
+    },
+
+    /**
+     * Waits for a property on the object that has the event interface
+     * to be available. That property MUST EVALUATE TO A TRUTHY VALUE.
+     * hasOwnProperty is not used because many objects are created with
+     * null placeholders to give a proper JS engine shape to them, and
+     * this method should not trigger the listener for those cases.
+     * If the property is already available, call the listener right
+     * away. If not available right away, listens for an event name that
+     * matches the property name.
+     * @param  {String}   id property name.
+     * @param  {Function} fn listener.
+     */
+    latest: function(id, fn) {
+      if (this[id] && !this._pendingEvents[id]) {
+        fn(this[id]);
+      }
+      this.on(id, fn);
+    },
+
+    /**
+     * Same as latest, but only calls the listener once.
+     * @param  {String}   id property name.
+     * @param  {Function} fn listener.
+     */
+    latestOnce: function(id, fn) {
+      if (this[id] && !this._pendingEvents[id])
+        fn(this[id]);
+      else
+        this.once(id, fn);
+    },
+
+    removeListener: function(id, fn) {
+      var i,
+          listeners = this._events[id];
+      if (listeners) {
+        i = listeners.indexOf(fn);
+        if (i !== -1) {
+          listeners.splice(i, 1);
+        }
+        if (listeners.length === 0)
+          delete this._events[id];
+      }
+    },
+
+    /**
+     * Like emit, but if no listeners yet, holds on
+     * to the value until there is one. Any other
+     * args after first one are passed to listeners.
+     * @param  {String} id event ID.
+     */
+    emitWhenListener: function(id) {
+      var listeners = this._events[id];
+      if (listeners) {
+        this.emit.apply(this, arguments);
+      } else {
+        if (!this._pendingEvents[id])
+          this._pendingEvents[id] = [];
+        this._pendingEvents[id].push(slice.call(arguments, 1));
+      }
+    },
+
+    emit: function(id) {
+      var args = slice.call(arguments, 1),
+          listeners = this._events[id];
+      if (listeners) {
+        listeners.forEach(function(fn) {
+          try {
+            fn.apply(null, args);
+          } catch (e) {
+            // Throw at later turn so that other listeners
+            // can complete. While this messes with the
+            // stack for the error, continued operation is
+            // valued more in this tradeoff.
+            setTimeout(function() {
+              throw e;
+            });
+          }
+        });
+      }
+    }
+  };
+
+  evt = new Emitter();
+  evt.Emitter = Emitter;
+
+  evt.mix = function(obj) {
+    var e = new Emitter();
+    props.forEach(function(prop) {
+      if (obj.hasOwnProperty(prop)) {
+        throw new Error('Object already has a property "' + prop + '"');
+      }
+      obj[prop] = e[prop];
+    });
+    return obj;
+  };
+
+  return evt;
+});

--- a/data/lib/mailapi/activesync/account.js
+++ b/data/lib/mailapi/activesync/account.js
@@ -179,6 +179,8 @@ ActiveSyncAccount.prototype = {
       problems: this.problems,
 
       syncRange: this.accountDef.syncRange,
+      syncInterval: this.accountDef.syncInterval,
+      notifyOnNew: this.accountDef.notifyOnNew,
 
       identities: this.identities,
 
@@ -206,34 +208,6 @@ ActiveSyncAccount.prototype = {
 
   get numActiveConns() {
     return 0;
-  },
-
-  saveAccountState: function asa_saveAccountState(reuseTrans, callback,
-                                                  reason) {
-    if (!this._alive) {
-      this._LOG.accountDeleted('saveAccountState');
-      return;
-    }
-
-    var account = this;
-    var perFolderStuff = [];
-    for (var iter in Iterator(this.folders)) {
-      var folder = iter[1];
-      var folderStuff = this._folderStorages[folder.id]
-                           .generatePersistenceInfo();
-      if (folderStuff)
-        perFolderStuff.push(folderStuff);
-    }
-
-    this._LOG.saveAccountState(reason);
-    var trans = this._db.saveAccountFolderStates(
-      this.id, this._folderInfos, perFolderStuff, this._deadFolderIds,
-      function stateSaved() {
-        if (callback)
-         callback();
-      }, reuseTrans);
-    this._deadFolderIds = null;
-    return trans;
   },
 
   /**
@@ -802,6 +776,8 @@ ActiveSyncAccount.prototype = {
   runOp: $acctmixins.runOp,
   getFirstFolderWithType: $acctmixins.getFirstFolderWithType,
   getFolderByPath: $acctmixins.getFolderByPath,
+  saveAccountState: $acctmixins.saveAccountState,
+  runAfterSaves: $acctmixins.runAfterSaves
 };
 
 var LOGFAB = exports.LOGFAB = $log.register($module, {

--- a/data/lib/mailapi/activesync/configurator.js
+++ b/data/lib/mailapi/activesync/configurator.js
@@ -137,6 +137,10 @@ exports.configurator = {
           type: 'activesync',
           syncRange: 'auto',
 
+          syncInterval: userDetails.syncInterval || 0,
+          notifyOnNew: userDetails.hasOwnProperty('notifyOnNew') ?
+                       userDetails.notifyOnNew : true,
+
           credentials: credentials,
           connInfo: {
             server: domainInfo.incoming.server
@@ -175,6 +179,9 @@ exports.configurator = {
 
       type: 'activesync',
       syncRange: oldAccountDef.syncRange,
+      syncInterval: oldAccountDef.syncInterval || 0,
+      notifyOnNew: oldAccountDef.hasOwnProperty('notifyOnNew') ?
+                   oldAccountDef.notifyOnNew : true,
 
       credentials: credentials,
       connInfo: {

--- a/data/lib/mailapi/composite/account.js
+++ b/data/lib/mailapi/composite/account.js
@@ -93,6 +93,8 @@ CompositeAccount.prototype = {
       problems: this.problems,
 
       syncRange: this.accountDef.syncRange,
+      syncInterval: this.accountDef.syncInterval,
+      notifyOnNew: this.accountDef.notifyOnNew,
 
       identities: this.identities,
 
@@ -133,6 +135,18 @@ CompositeAccount.prototype = {
 
   saveAccountState: function(reuseTrans, callback, reason) {
     return this._receivePiece.saveAccountState(reuseTrans, callback, reason);
+  },
+
+  get _saveAccountIsImminent() {
+    return this.__saveAccountIsImminent;
+  },
+  set _saveAccountIsImminent(val) {
+    this.___saveAccountIsImminent =
+    this._receivePiece._saveAccountIsImminent = val;
+  },
+
+  runAfterSaves: function(callback) {
+    return this._receivePiece.runAfterSaves(callback);
   },
 
   /**

--- a/data/lib/mailapi/composite/configurator.js
+++ b/data/lib/mailapi/composite/configurator.js
@@ -113,6 +113,9 @@ exports.configurator = {
       sendType: 'smtp',
 
       syncRange: oldAccountDef.syncRange,
+      syncInterval: oldAccountDef.syncInterval || 0,
+      notifyOnNew: oldAccountDef.hasOwnProperty('notifyOnNew') ?
+                   oldAccountDef.notifyOnNew : true,
 
       credentials: credentials,
       receiveConnInfo: {
@@ -164,6 +167,9 @@ exports.configurator = {
       sendType: 'smtp',
 
       syncRange: 'auto',
+      syncInterval: userDetails.syncInterval || 0,
+      notifyOnNew: userDetails.hasOwnProperty('notifyOnNew') ?
+                   userDetails.notifyOnNew : true,
 
       credentials: credentials,
       receiveConnInfo: imapConnInfo,

--- a/data/lib/mailapi/mailapi.js
+++ b/data/lib/mailapi/mailapi.js
@@ -39,6 +39,8 @@ function MailAccount(api, wireRep, acctsSlice) {
   this.type = wireRep.type;
   this.name = wireRep.name;
   this.syncRange = wireRep.syncRange;
+  this.syncInterval = wireRep.syncInterval;
+  this.notifyOnNew = wireRep.notifyOnNew;
 
   /**
    * Is the account currently enabled, as in will we talk to the server?
@@ -96,6 +98,8 @@ MailAccount.prototype = {
   __update: function(wireRep) {
     this.enabled = wireRep.enabled;
     this.problems = wireRep.problems;
+    this.syncInterval = wireRep.syncInterval;
+    this.notifyOnNew = wireRep.notifyOnNew;
     this._wireRep.defaultPriority = wireRep.defaultPriority;
   },
 
@@ -163,7 +167,7 @@ function MailSenderIdentity(api, wireRep) {
   this._api = api;
   this.id = wireRep.id;
 
-  this.name = wireRep.displayName;
+  this.name = wireRep.name;
   this.address = wireRep.address;
   this.replyTo = wireRep.replyTo;
   this.signature = wireRep.signature;
@@ -1769,8 +1773,7 @@ MessageComposition.prototype = {
 
 };
 
-
-var LEGAL_CONFIG_KEYS = ['syncCheckIntervalEnum'];
+var LEGAL_CONFIG_KEYS = [];
 
 /**
  * Error reporting helper; we will probably eventually want different behaviours
@@ -3051,6 +3054,35 @@ MailAPI.prototype = {
   },
 
   //////////////////////////////////////////////////////////////////////////////
+  // mode setting for back end universe. Set interactive
+  // if the user has been exposed to the UI and it is a
+  // longer lived application, not just a cron sync.
+  setInteractive: function() {
+    this.__bridgeSend({
+      type: 'setInteractive'
+    });
+  },
+
+  //////////////////////////////////////////////////////////////////////////////
+  // cron syncing
+
+  /**
+   * Receive events about the start and stop of periodic syncing
+   */
+  _recv_cronSyncStart: function ma__recv_cronSyncStart(msg) {
+    if (this.oncronsyncstart)
+      this.oncronsyncstart(msg.accountIds);
+    return true;
+  },
+
+  _recv_cronSyncStop: function ma__recv_cronSyncStop(msg) {
+    if (this.oncronsyncstop)
+      this.oncronsyncstop(msg.accountsResults);
+    return true;
+  },
+
+
+  //////////////////////////////////////////////////////////////////////////////
   // Localization
 
   /**
@@ -3102,6 +3134,7 @@ MailAPI.prototype = {
     }
     return name;
   },
+
 
   //////////////////////////////////////////////////////////////////////////////
   // Configuration

--- a/data/lib/mailapi/mailbridge.js
+++ b/data/lib/mailapi/mailbridge.js
@@ -8,6 +8,7 @@ define(
     './util',
     './mailchew-strings',
     './date',
+    './slice_bridge_proxy',
     'require',
     'module',
     'exports'
@@ -17,12 +18,14 @@ define(
     $imaputil,
     $mailchewStrings,
     $date,
+    $sliceBridgeProxy,
     require,
     $module,
     exports
   ) {
 var bsearchForInsert = $imaputil.bsearchForInsert,
-    bsearchMaybeExists = $imaputil.bsearchMaybeExists;
+    bsearchMaybeExists = $imaputil.bsearchMaybeExists,
+    SliceBridgeProxy = $sliceBridgeProxy.SliceBridgeProxy;
 
 function toBridgeWireOn(x) {
   return x.toBridgeWire();
@@ -82,7 +85,7 @@ function checkIfAddressListContainsAddress(list, addrPair) {
       return true;
   }
   return false;
-};
+}
 
 /**
  * There is exactly one `MailBridge` instance for each `MailAPI` instance.
@@ -185,6 +188,10 @@ MailBridge.prototype = {
     }
   },
 
+  _cmd_setInteractive: function mb__cmd_setInteractive(msg) {
+    this.universe.setInteractive();
+  },
+
   _cmd_localizedStrings: function mb__cmd_localizedStrings(msg) {
     $mailchewStrings.set(msg.strings);
   },
@@ -260,6 +267,14 @@ MailBridge.prototype = {
 
         case 'syncRange':
           accountDef.syncRange = val;
+          break;
+
+        case 'syncInterval':
+          accountDef.syncInterval = val;
+          break;
+
+        case 'notifyOnNew':
+          accountDef.notifyOnNew = val;
           break;
 
         case 'setAsDefault':
@@ -1127,91 +1142,21 @@ MailBridge.prototype = {
     }.bind(this));
   },
 
+  notifyCronSyncStart: function mb_notifyCronSyncStart(accountIds) {
+    this.__sendMessage({
+      type: 'cronSyncStart',
+      accountIds: accountIds
+    });
+  },
+
+  notifyCronSyncStop: function mb_notifyCronSyncStop(accountsResults) {
+    this.__sendMessage({
+      type: 'cronSyncStop',
+      accountsResults: accountsResults
+    });
+  }
+
   //////////////////////////////////////////////////////////////////////////////
-};
-
-function SliceBridgeProxy(bridge, ns, handle) {
-  this._bridge = bridge;
-  this._ns = ns;
-  this._handle = handle;
-  this.__listener = null;
-
-  this.status = 'synced';
-  this.progress = 0.0;
-  this.atTop = false;
-  this.atBottom = false;
-  /**
-   * Can we potentially grow the slice in the negative direction if explicitly
-   * desired by the user or UI desires to be up-to-date?  For example,
-   * triggering an IMAP sync.
-   *
-   * This is only really meaningful when `atTop` is true; if we are not at the
-   * top then this value will be false.
-   *
-   * For messages, the implication is that we are not synchronized through 'now'
-   * if this value is true (and atTop is true).
-   */
-  this.userCanGrowUpwards = false;
-  this.userCanGrowDownwards = false;
-}
-SliceBridgeProxy.prototype = {
-  /**
-   * Issue a splice to add and remove items.
-   * @param {number} newEmailCount Number of new emails synced during this
-   *     slice request.
-   */
-  sendSplice: function sbp_sendSplice(index, howMany, addItems, requested,
-                                      moreExpected, newEmailCount) {
-    this._bridge.__sendMessage({
-      type: 'sliceSplice',
-      handle: this._handle,
-      index: index,
-      howMany: howMany,
-      addItems: addItems,
-      requested: requested,
-      moreExpected: moreExpected,
-      status: this.status,
-      progress: this.progress,
-      atTop: this.atTop,
-      atBottom: this.atBottom,
-      userCanGrowUpwards: this.userCanGrowUpwards,
-      userCanGrowDownwards: this.userCanGrowDownwards,
-      newEmailCount: newEmailCount,
-    });
-  },
-
-  /**
-   * Issue an update for existing items.
-   */
-  sendUpdate: function sbp_sendUpdate(indexUpdatesRun) {
-    this._bridge.__sendMessage({
-      type: 'sliceUpdate',
-      handle: this._handle,
-      updates: indexUpdatesRun,
-    });
-  },
-
-  /**
-   * @param {number} newEmailCount Number of new emails synced during this
-   *     slice request.
-   */
-  sendStatus: function sbp_sendStatus(status, requested, moreExpected,
-                                      progress, newEmailCount) {
-    this.status = status;
-    if (progress != null)
-      this.progress = progress;
-    this.sendSplice(0, 0, [], requested, moreExpected, newEmailCount);
-  },
-
-  sendSyncProgress: function(progress) {
-    this.progress = progress;
-    this.sendSplice(0, 0, [], true, true);
-  },
-
-  die: function sbp_die() {
-    if (this.__listener)
-      this.__listener.die();
-  },
 };
 
 var LOGFAB = exports.LOGFAB = $log.register($module, {

--- a/data/lib/mailapi/mailslice.js
+++ b/data/lib/mailapi/mailslice.js
@@ -1060,13 +1060,6 @@ FolderStorage.prototype = {
   },
 
   /**
-   * Function that we call with header whenever addMessageHeader gets called.
-   * @type {Function}
-   * @private
-   */
-  _onAddingHeader: null,
-
-  /**
    * Reset all active slices.
    */
   resetAndRefreshActiveSlices: function() {
@@ -2678,10 +2671,12 @@ FolderStorage.prototype = {
        * 2. and this hasn't already been seen.
        * @param {HeaderInfo} header The header being added.
        */
-      this._onAddingHeader = function(header) {
+      slice._onAddingHeader = function(header, currentSlice) {
         if (SINCE(header.date, prevTS) &&
             (!header.flags || header.flags.indexOf('\\Seen') === -1)) {
           newEmailCount += 1;
+          if (slice.onNewHeader)
+            slice.onNewHeader(header);
         }
       }.bind(this);
 
@@ -2715,7 +2710,7 @@ FolderStorage.prototype = {
 
     var doneCallback = function refreshDoneCallback(err, bisectInfo,
                                                     numMessages) {
-      this._onAddingHeader = null;
+      slice._onAddingHeader = null;
 
       var reportSyncStatusAs = 'synced';
       switch (err) {
@@ -3691,9 +3686,9 @@ FolderStorage.prototype = {
           slice.desiredHeaders++;
         }
 
-        if (this._onAddingHeader !== null) {
-          this._onAddingHeader(header);
-        }
+        if (slice._onAddingHeader)
+          slice._onAddingHeader(header);
+
         slice.onHeaderAdded(header, false, true);
       }
     }

--- a/data/lib/mailapi/main-frame-setup.js
+++ b/data/lib/mailapi/main-frame-setup.js
@@ -46,9 +46,7 @@ define(
     sendMessage: null,
     process: function(uid, cmd, args) {
       var online = navigator.onLine;
-      var hasPendingAlarm = navigator.mozHasPendingMessage &&
-                            navigator.mozHasPendingMessage('alarm');
-      control.sendMessage(uid, 'hello', [online, hasPendingAlarm]);
+      control.sendMessage(uid, 'hello', [online]);
 
       window.addEventListener('online', function(evt) {
         control.sendMessage(uid, evt.type, [true]);
@@ -56,11 +54,6 @@ define(
       window.addEventListener('offline', function(evt) {
         control.sendMessage(uid, evt.type, [false]);
       });
-      if (navigator.mozSetMessageHandler) {
-        navigator.mozSetMessageHandler('alarm', function(msg) {
-          control.sendMessage(uid, 'alarm', [msg]);
-        });
-      }
 
       $router.unregister(control);
     },

--- a/data/lib/mailapi/slice_bridge_proxy.js
+++ b/data/lib/mailapi/slice_bridge_proxy.js
@@ -1,0 +1,97 @@
+/*global define */
+define(
+  [
+    'exports'
+  ],
+  function(
+    exports
+  ) {
+
+function SliceBridgeProxy(bridge, ns, handle) {
+  this._bridge = bridge;
+  this._ns = ns;
+  this._handle = handle;
+  this.__listener = null;
+
+  this.status = 'synced';
+  this.progress = 0.0;
+  this.atTop = false;
+  this.atBottom = false;
+  /**
+   * Can we potentially grow the slice in the negative direction if explicitly
+   * desired by the user or UI desires to be up-to-date?  For example,
+   * triggering an IMAP sync.
+   *
+   * This is only really meaningful when `atTop` is true; if we are not at the
+   * top then this value will be false.
+   *
+   * For messages, the implication is that we are not synchronized through 'now'
+   * if this value is true (and atTop is true).
+   */
+  this.userCanGrowUpwards = false;
+  this.userCanGrowDownwards = false;
+}
+
+exports.SliceBridgeProxy = SliceBridgeProxy;
+
+SliceBridgeProxy.prototype = {
+  /**
+   * Issue a splice to add and remove items.
+   * @param {number} newEmailCount Number of new emails synced during this
+   *     slice request.
+   */
+  sendSplice: function sbp_sendSplice(index, howMany, addItems, requested,
+                                      moreExpected, newEmailCount) {
+    this._bridge.__sendMessage({
+      type: 'sliceSplice',
+      handle: this._handle,
+      index: index,
+      howMany: howMany,
+      addItems: addItems,
+      requested: requested,
+      moreExpected: moreExpected,
+      status: this.status,
+      progress: this.progress,
+      atTop: this.atTop,
+      atBottom: this.atBottom,
+      userCanGrowUpwards: this.userCanGrowUpwards,
+      userCanGrowDownwards: this.userCanGrowDownwards,
+      newEmailCount: newEmailCount,
+    });
+  },
+
+  /**
+   * Issue an update for existing items.
+   */
+  sendUpdate: function sbp_sendUpdate(indexUpdatesRun) {
+    this._bridge.__sendMessage({
+      type: 'sliceUpdate',
+      handle: this._handle,
+      updates: indexUpdatesRun,
+    });
+  },
+
+  /**
+   * @param {number} newEmailCount Number of new emails synced during this
+   *     slice request.
+   */
+  sendStatus: function sbp_sendStatus(status, requested, moreExpected,
+                                      progress, newEmailCount) {
+    this.status = status;
+    if (progress != null)
+      this.progress = progress;
+    this.sendSplice(0, 0, [], requested, moreExpected, newEmailCount);
+  },
+
+  sendSyncProgress: function(progress) {
+    this.progress = progress;
+    this.sendSplice(0, 0, [], true, true);
+  },
+
+  die: function sbp_die() {
+    if (this.__listener)
+      this.__listener.die();
+  },
+};
+
+});

--- a/data/lib/mailapi/worker-setup.js
+++ b/data/lib/mailapi/worker-setup.js
@@ -51,8 +51,6 @@ var sendControl = $router.registerSimple('control', function(data) {
   var args = data.args;
   switch (data.cmd) {
     case 'hello':
-      navigator.hasPendingAlarm = args[1];
-
       universe = new $mailuniverse.MailUniverse(onUniverse, args[0]);
       break;
 

--- a/data/lib/mailapi/worker-support/maildb-main.js
+++ b/data/lib/mailapi/worker-support/maildb-main.js
@@ -57,6 +57,9 @@ if (("indexedDB" in window) && window.indexedDB) {
  *
  * Explanation of most recent bump:
  *
+ * Bumping to 22 because of account changes around cronsyncing, an "undefined"
+ * error with summaries and some constant changes.
+ *
  * Bumping to 21 because of massive error in partial fetching merges.
  *
  * Bumping to 20 because of block sizing changes.
@@ -71,7 +74,7 @@ if (("indexedDB" in window) && window.indexedDB) {
  * Bumping to 17 because we changed the folder representation to store
  * hierarchy.
  */
-var CUR_VERSION = 21;
+var CUR_VERSION = 22;
 
 /**
  * What is the lowest database version that we are capable of performing a

--- a/data/lib/mailapi/worker-support/main-router.js
+++ b/data/lib/mailapi/worker-support/main-router.js
@@ -6,12 +6,24 @@ define(function() {
   var worker = null;
 
   function register(module) {
-    var name = module.name;
+    var action,
+        name = module.name;
+
     modules.push(module);
 
-    listeners[name] = function(msg) {
-      module.process(msg.uid, msg.cmd, msg.args);
-    };
+    if (module.process) {
+      action = function(msg) {
+        module.process(msg.uid, msg.cmd, msg.args);
+      };
+    } else if (module.dispatch) {
+      action = function(msg) {
+        if (module.dispatch[msg.cmd]) {
+          module.dispatch[msg.cmd].apply(module.dispatch, msg.args);
+        }
+      };
+    }
+
+    listeners[name] = action;
 
     module.sendMessage = function(uid, cmd, args, transferArgs) {
     //dump('\x1b[34mM => w: send: ' + name + ' ' + uid + ' ' + cmd + '\x1b[0m\n');

--- a/scripts/copy-to-gaia.js
+++ b/scripts/copy-to-gaia.js
@@ -26,6 +26,9 @@ buildOptions = {
     'alameda': 'deps/alameda',
     'config': 'scripts/config',
 
+    // front end of mail supplies its own evt
+    'evt': 'empty:',
+
     // NOP's
     'prim': 'empty:',
     'http': 'data/lib/nop',

--- a/test/gelam-require-map.js
+++ b/test/gelam-require-map.js
@@ -15,6 +15,7 @@ require({
     // - map similar to the one in copy-to-gaia.js
 
     // NOP's
+    "evt": "data/lib/evt",
     "http": "data/lib/nop",
     "https": "data/lib/nop2",
     "url": "data/lib/nop3",
@@ -63,6 +64,7 @@ require({
     "simplesmtp": "data/deps/simplesmtp",
     "mailcomposer": "data/deps/mailcomposer",
   },
+  definePrim: 'prim'
 });
 require(['loggest-runner.js'], function() {});
 

--- a/test/worker-bootstrap.js
+++ b/test/worker-bootstrap.js
@@ -112,4 +112,5 @@ require({
     "simplesmtp": "data/deps/simplesmtp",
     "mailcomposer": "data/deps/mailcomposer",
   },
+  definePrim: 'prim'
 }, ['loggest-runner-worker']);


### PR DESCRIPTION
Preliminary GELAM pull request. While this code works and has had some end-to-end testing on a phone, there is a high likelihood it will need some changes before it is merge-worthy. Most importantly, it is lacking tests. Doing a pull request now though to work through any higher level design issues first.

Terms:
- BE: back end: usually means GELAM itself, including the main-frame-setup.js and code under that, the worker code.
- FE: front end: the code in gaia for showing the email UI and front end logic.
### General notes

The general approach: use cronsync as an instance property of mailuniverse to manage syncing. cronsyn-main is outside the worker, so it can set alarms and receive notifications of triggered alarms.

mailuniverse is the facade in front of the cron work, with it handling the triggering of "cron start" and "cron stop" events that go through the mailbridge and mailapi that are then visible to the FE. The "cron stop" event will have any data about new messsages. Right now that data is: for each account that has new messages, how many new and then

There are debug statements that should probably be removed or at least
switched off.
### evt.js

evt.js from the FE was added to the BE, and used by cronsync-main.js to send out the list of wake locks. When copying the files into gaia, the evt.js in GELAM is not copied over, the FE copy is used.

This was done because acquiring the wake locks need to happen during the alarm event loop tick as further ones may be shut down by the system, but the release of the locks need to occur after the FE has figured out how to notify. So a evt.js is used as a pub/sub method in this case with the receiver not being known to GELAM (but wired up by the gaia FE).
### New account properties

**syncInterval**: defaults to 0 for upgrades, meaning no syncing.

**notifyOnNew**: defaults to false for upgrades (if new account is created by FE
after this patch lands, FE defaults to true)
### cron changes

Updates cronslice to latest slice expectations, and pulls it out as a separate file from cronsync.

It also uses $sync.INITIAL_FILL_SIZE for desiredHeaders, felt it was better to use an existing constant than one that may not match if that constant it is related to changes later.

cronsync talks to cronsync-main over postMessage via $router.

Syncing tries to group account IDs that are on the same interval together, so all the cron-related methods accept an array of account IDs.

cronsync is driven by two mechanisms:
- **mailuniverse**: on account startup, if there is a syncInterval on the account, then ensureSync will be called to make sure alarm is still set and set correctly for the account. This should help in cases where the mail app gets killed or dies at inopportune times before the next sync alarm is set.
- as mozAlarms fire, **cronsync-main** listens for them, and tells cronsync about it.
### mailapi/malapi
- passes through the new sync-related account variables.
- Removes modifyConfig, as it only seemed to be used for syncInterval when that value was global. This may have been too aggressive.
- exposes an oncronsyncstart and oncronsyncstop that the FE can use to get notifications of when cronsyncing starts and stops.
### mailuniverse
- makeBridgeFn: just encapsulates some boilerplate for setting up some pass-through messaging functions.
- Renamed _cronSyncer to _cronSync to better match module name. I wonder if this should go further and perhaps cronsync should be a singleton as the cronsync-main.js sends messages in a way that it assumes a static entity receiving them.
- Calls _cronSync.ensureSync if syncInterval is in play, otherwise, it does the old syncFolderList call.
- Bridges the notifications coming out of _cronSync with what is sent over the mailbridge, as the "cronstop" state needs to wait for a final DB account save (usually for the snippets) before sending out the cronstop event. Without this, the FE was shutting down the app before final DB write was done.
