### PR TITLE
Bug 892518 - email: [User Story] Ability to Change Sync Interval

### DIFF
--- a/data/lib/mailapi/worker-support/cronsync-main.js
+++ b/data/lib/mailapi/worker-support/cronsync-main.js
@@ -146,9 +146,7 @@ define(function(require) {
       var request = mozAlarms.getAll();
 
       request.onsuccess = function(event) {
-        var alarms = event.target.result;
-        if (!alarms)
-          return;
+        var alarms = event.target.result || [];
 
         // Find all IDs being tracked by alarms
         var expiredAlarmIds = [],


### PR DESCRIPTION
While doing the integration test for bug 892518, tracing through the logic, I found a small issue where if no alarms are found, the exit early inside mozAlarms.getAll() onsuccess if no alarms would mean not sending the 'syncEnsured' message back to the worker, which means the cronsync may not send future ensureSync checks since it blocks further calls until it gets a response from cronsync-main's ensureSync.

This change will be rolled up into the gaia changeset for 892518.
