### PR TITLE
Bug 918995 - [1.2][email] Multiple email notification should have senders listed in reverse chronological order of email timestamp

### DIFF
--- a/data/lib/mailapi/cronsync.js
+++ b/data/lib/mailapi/cronsync.js
@@ -237,6 +237,7 @@ CronSync.prototype = {
       var notifyHeaders = [];
       newHeaders.some(function(header, i) {
         notifyHeaders.push({
+          date: header.date,
           from: header.author.name || header.author.address,
           subject: header.subject,
           accountId: account.id,


### PR DESCRIPTION
Add the date item in notify header.
http://bugzil.la/918995
