### PR TITLE
Modify README.md to clarify setup steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ git clone --recursive https://github.com/mozilla-b2g/gaia-email-libs-and-more.gi
 
 3. Install node.js - Standard package management is fine (apt-get, brew, etc).
 
-4. Install npm
+4. Install npm. If you have installed node.js from source, you don't need to install npm as it is built with node.js.
+  If you use a package management system, you may need to install this separately.
 
 5. Clone push log, do it recursively - https://github.com/asutherland/arbitrarypushlog/tree/master
 


### PR DESCRIPTION
Incorporating feedback from https://bugzilla.mozilla.org/show_bug.cgi?id=936760. 

> Step 3 installs step 4 (install npm) I think.  Recent versions of node ship with it.  Maybe we should just specify node 0.10.x.  (We probably still work on 0.8.x, but I'm not sure why we'd want to advocate an older version.)

At least on OS X and My ubuntu VM, I had to install npm separately using brew / apt-get after installing node.js. Maybe if a person downloads the source and compiles it installs automatically? My OS X Node is 0.10.21 and my Ubuntu version is v0.10.15. 
