### PR TITLE
Bug 972514 - test clause got left out. [B2G][Email]Flagged Hotmail emails do not display the changed on or off flag indicator when synced from the server to the device using ActiveSync. r=mcav

### DIFF
--- a/test/unit/test_sync_server_changes.js
+++ b/test/unit/test_sync_server_changes.js
@@ -81,6 +81,19 @@ TD.commonCase('detect server changes', function(T) {
     expectedRefreshChanges,
     { top: true, bottom: true, grow: false, newCount: 0 });
 
+
+  T.group('fail to get the message body for a deleted message');
+  T.action(eSync, 'request deleted message body from',
+           testFolder.storageActor, function() {
+    eSync.expect_namedValue('bodyInfo', null);
+    testFolder.storageActor.expect_bodyNotFound();
+    var deletedHeader = expectedRefreshChanges.deletions[0];
+    deletedHeader.getBody(function(bodyInfo) {
+      eSync.namedValue('bodyInfo', bodyInfo);
+      // it's null so we don't call bodyInfo.die(), but if it wasn't...!
+    });
+  });
+
   T.group('cleanup');
   testAccount.do_closeFolderView(checkView);
 });


### PR DESCRIPTION
While migrating this test logic a hunk got left out in https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/286.  This was unintentional and since this was already verbatim in the other test file, landing it.
