### PR TITLE
Bug 977867 - [email/IMAP] wait for server greeting before sending commands to workaround gmail issue

### DIFF
--- a/data/lib/imap.js
+++ b/data/lib/imap.js
@@ -7,11 +7,12 @@ var util = require('util'), $log = require('rdcommon/log'),
 var emptyFn = function() {}, CRLF = '\r\n',
     CRLF_BUFFER = Buffer(CRLF),
     STATES = {
-      NOCONNECT: 0,
-      NOAUTH: 1,
-      AUTH: 2,
-      BOXSELECTING: 3,
-      BOXSELECTED: 4
+      NOCONNECT: 0, // not connected yet
+      NOGREET: 1, // waiting for a greeting / anything from the server
+      NOAUTH: 2, // not yet authenticated
+      AUTH: 3, // authenticated but we're not currently "in" a folder
+      BOXSELECTING: 4, // authenticated, trying to select/examine a folder
+      BOXSELECTED: 5 // authetnciated, successfully selected/examined a folder
     }, BOX_ATTRIBS = ['NOINFERIORS', 'NOSELECT', 'MARKED', 'UNMARKED'],
     MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep',
               'Oct', 'Nov', 'Dec'],
@@ -171,8 +172,8 @@ function ImapConnection (options) {
     requests: [],
     unsentRequests: [],
     activeRequests: 0,
+    postGreetingCallback: null,
     numCapRecvs: 0,
-    isReady: false,
     isIdle: true,
     tmrConn: null,
     curData: null,
@@ -289,9 +290,7 @@ ImapConnection.prototype._findFetchRequest = function(uid, bodyPart) {
 ImapConnection.prototype.connect = function(loginCb) {
   var self = this,
       fnInit = function() {
-        // First get pre-auth capabilities, including server-supported auth
-        // mechanisms
-        self._send('CAPABILITY', null, function() {
+        var attemptLogin = function() {
           // Next, attempt to login
           var checkedNS = false;
           var redo = function(err, reentry) {
@@ -312,7 +311,16 @@ ImapConnection.prototype.connect = function(loginCb) {
             self._send('LIST "" ""', null, loginCb);
           };
           self._login(redo);
-        });
+        };
+
+        // Get pre-auth capabilities, including server-supported auth mechanisms
+        // if we didn't hear them in the server greeting.
+        if (self._state.numCapRecvs === 0) {
+          self._send('CAPABILITY', null, attemptLogin);
+        }
+        else {
+          attemptLogin();
+        }
       };
   loginCb = loginCb || emptyFn;
   this._reset();
@@ -331,9 +339,18 @@ ImapConnection.prototype.connect = function(loginCb) {
       clearTimeoutFunc(self._state.tmrConn);
       self._state.tmrConn = null;
     }
-    self._state.status = STATES.NOAUTH;
+    if (self._state.status === STATES.NOCONNECT) {
+      self._state.status = STATES.NOGREET;
+    }
+  });
 
+  this._state.postGreetingCallback = function() {
     if (self._options.crypto === 'starttls') {
+      // we don't need to issue an explicit CAPABILITY request before issuing
+      // STARTTLS because it's game over if there is no STARTTLS.
+      // Coincidentally, we also want to ignore any insecure unsolicited
+      // CAPABILITY we got in the server greeting.
+      self._state.numCapRecvs = 0;
       self._send('STARTTLS', null, function(err) {
         if (err) {
           var securityErr = new Error('Server does not support STARTTLS');
@@ -348,7 +365,7 @@ ImapConnection.prototype.connect = function(loginCb) {
     }
 
     fnInit();
-  });
+  };
 
   this._state.conn.on('data', function(buffer) {
     try {
@@ -369,20 +386,43 @@ ImapConnection.prototype.connect = function(loginCb) {
     var curReq = null;
     // -- Untagged server responses
     if (data[0] === '*') {
-      if (self._state.status === STATES.NOAUTH) {
-        if (data[1] === 'PREAUTH') { // the server pre-authenticated us
+      // We haven't heard anything from the server yet, this should be the
+      // greeting.
+      if (self._state.status === STATES.NOGREET) {
+        // The greeting is one of 3 things:
+        // - Pre-authentication indication, jump to being authenticated.
+        if (data[1] === 'PREAUTH') {
           self._state.status = STATES.AUTH;
-          if (self._state.numCapRecvs === 0)
+          if (self._state.numCapRecvs === 0) {
             self._state.numCapRecvs = 1;
+          }
+          return;
+        // - The server hates us, hang up.
         } else if (data[1] === 'NO' || data[1] === 'BAD' || data[1] === 'BYE') {
           if (self._LOG && data[1] === 'BAD')
             self._LOG.bad(data[2]);
           self._state.conn.end();
           return;
         }
-        if (!self._state.isReady)
-          self._state.isReady = true;
-        // Restrict the type of server responses when unauthenticated
+        // - The server is okay with us
+        // Check if we got an inline CAPABILITY like dovecot likes to do.
+        if (data[2].startsWith('[CAPABILITY ')) {
+          self._state.numCapRecvs = 1;
+          self.capabilities = data[2].substring(12, data[2].lastIndexOf(']'))
+                                     .split(' ').map(up);
+        }
+        // Advance to STARTTLS/CAPABILITY request
+        self._state.status = STATES.NOAUTH;
+        if (self._state.postGreetingCallback) {
+          var callback = self._state.postGreetingCallback;
+          self._state.postGreetingCallback = null;
+          callback();
+        }
+        return;
+      }
+      if (self._state.status === STATES.NOAUTH) {
+        // Since we explicitly break out the pre-greeting state now, this
+        // state really just exists to filter out weird unsolicited responses.
         if (data[1] !== 'CAPABILITY' && data[1] !== 'ALERT')
           return;
       }
@@ -971,7 +1011,9 @@ ImapConnection.prototype.die = function() {
     this._state.conn.end();
   }
   this._reset();
-  this._LOG.__die();
+  if (this._LOG) {
+    this._LOG.__die();
+  }
 };
 
 ImapConnection.prototype.isAuthenticated = function() {
@@ -1550,8 +1592,8 @@ ImapConnection.prototype._reset = function() {
   this._state.numCapRecvs = 0;
   this._state.requests = [];
   this._state.unsentRequests = [];
+  this._state.postGreetingCallback = null;
   this._state.isIdle = true;
-  this._state.isReady = false;
   this._state.ext.idle.state = IDLE_NONE;
   this._state.ext.idle.timeWaited = 0;
 

--- a/test/unit/test_imap_proto.js
+++ b/test/unit/test_imap_proto.js
@@ -1,13 +1,14 @@
 /**
- * IMAP protocol implementation tests.  Really I'm just creating this for
- * the modified utf-7 decoding test.
+ * IMAP protocol implementation tests.  Also check out test_incoming_prober.js.
  */
 
-define(['rdcommon/testcontext', './resources/th_main', 'imap', 'exports'],
-       function($tc, $th_imap, $imap, exports) {
+define(['rdcommon/testcontext', './resources/th_main',
+  './resources/fault_injecting_socket', 'imap', 'exports'],
+function($tc, $th_main, $fawlty, $imap, exports) {
+var FawltySocketFactory = $fawlty.FawltySocketFactory;
 
 var TD = exports.TD = $tc.defineTestsFor(
-  { id: 'test_imap_proto' }, null, [$th_imap.TESTHELPER], ['app']);
+  { id: 'test_imap_proto' }, null, [$th_main.TESTHELPER], ['app']);
 
 TD.commonSimple('decodeModifiedUtf7', function(lazy) {
   var decodeModifiedUtf7 = $imap.decodeModifiedUtf7;
@@ -48,6 +49,154 @@ TD.commonSimple('parseImapDateTime', function(lazy) {
         Date.UTC(2013, 5, 4, 19, 15, 49));
   check('14-Jun-2013 14:15:49 -0500',
         Date.UTC(2013, 5, 14, 19, 15, 49));
+});
+
+function thunkTimeouts(lazyLogger) {
+  var timeouts = [];
+  function thunkedSetTimeout(func, delay) {
+    lazyLogger.namedValue('incoming:setTimeout', delay);
+    return timeouts.push(func);
+  }
+  function thunkedClearTimeout() {
+    lazyLogger.event('incoming:clearTimeout');
+  }
+
+  $imap.TEST_useTimeoutFuncs(thunkedSetTimeout, thunkedClearTimeout);
+  return function fireThunkedTimeout(index) {
+    timeouts[index]();
+    timeouts[index] = null;
+  };
+}
+
+// Currently all the tests in here are completely fake; we never connect.
+const HOST = 'localhost', PORT = 65535;
+var CONN_TIMEOUT = 10000;
+
+function makeCredsAndConnInfo() {
+  return {
+    username: 'USERNAME',
+    password: 'PASSWORD',
+    hostname: HOST,
+    port: PORT,
+    crypto: false,
+
+  };
+}
+
+/**
+ * Connection test helper.  Cases basically go like this:
+ * - setup connection, ensure no writes happen.
+ * - generate connect notification, ensure no writes happen.
+ * - send the server greeting (parameterized), expect a specific (parameterized)
+ *   response from this.
+ * - test over! we win! party at IMAP's house!
+ *
+ * @param opts.greeting
+ * @param opts.firstRequest
+ * @param opts.capabilities
+ */
+function cannedConnectTest(T, RT, opts) {
+  $th_main.thunkConsoleForNonTestUniverse();
+  var eCheck = T.lazyLogger('check');
+
+  var fireTimeout = thunkTimeouts(eCheck),
+      cci = makeCredsAndConnInfo(),
+      prober;
+
+  var imapConn = null;
+  T.action('create IMAP proto, see connect req, no write', eCheck, function() {
+    eCheck.expect_event('socket opened');
+    eCheck.expect_namedValue('incoming:setTimeout', CONN_TIMEOUT);
+
+    FawltySocketFactory.precommand(
+      HOST, PORT,
+      // make this a fake connection with no underlying real socket, but send
+      // nothing on connect.
+      {
+        cmd: 'fake-no-connect',
+        data: null
+      },
+      null,
+      // log all writes from the client.
+      {
+        callOnOpen: function() {
+          eCheck.event('socket opened');
+        },
+        callOnWrite: function(str) {
+          eCheck.namedValue('clientWrite', str);
+        }
+      });
+
+    imapConn = new $imap.ImapConnection(makeCredsAndConnInfo());
+    imapConn.connect();
+  });
+
+  var fakeSock;
+  T.action('send connect notification, see no writes', eCheck, function() {
+    fakeSock = FawltySocketFactory.getMostRecentLiveSocket();
+    // the connect notification should cancel the timeout, but that's it!
+    eCheck.expect_event('incoming:clearTimeout');
+    fakeSock._queueEvent('connect');
+  });
+
+  T.action('send greeting, see expected first write', eCheck, function() {
+    eCheck.expect_namedValue('clientWrite', opts.firstRequest);
+
+    fakeSock.doNow(
+      [
+        {
+          cmd: 'fake-receive',
+          data: opts.greeting
+        }
+      ]);
+  });
+
+  if (opts.capabilities) {
+    T.check(eCheck, 'capabilities', function() {
+      eCheck.expect_namedValue('capabilities', opts.capabilities);
+      eCheck.namedValue('capabilities', imapConn.capabilities);
+    });
+  }
+
+  T.cleanup('kill IMAP conn', eCheck, function() {
+    imapConn.die();
+  });
+}
+
+var NON_DOVECOT_GREETING = '* OK whatever\r\n';
+var CAPABILITY_REQUEST = 'A1 CAPABILITY\r\n';
+
+/**
+ * In https://bugzil.la/977867 gmail would ignore anything we managed to send
+ * prior to the greeting / in our TLS-finalization packet, so we need to make
+ * sure that we do not send our CAPABILITY request until the server issues
+ * a greeting.
+ */
+TD.commonCase('wait for server greeting, no inline CAPABILITY', function(T,RT) {
+  cannedConnectTest(T, RT, {
+    greeting: NON_DOVECOT_GREETING,
+    firstRequest: CAPABILITY_REQUEST
+  });
+});
+
+var DOVECOT_CAPABILITY_GREETING =
+  '* OK [CAPABILITY IMAP4rev1 LITERAL+ SASL-IR LOGIN-REFERRALS ID' +
+    ' ENABLE IDLE STARTTLS AUTH=PLAIN] Dovecot ready.\r\n';
+var DOVECOT_CAPABILITIES = [
+  'IMAP4REV1', 'LITERAL+', 'SASL-IR', 'LOGIN-REFERRALS', 'ID',
+  'ENABLE', 'IDLE', 'STARTTLS', 'AUTH=PLAIN'];
+var LOGIN_REQUEST = 'A1 LOGIN "USERNAME" "PASSWORD"\r\n';
+
+/**
+ * Same as the previous case but dovecot likes to send a CAPABILITY response
+ * in the greeting.  We should consume that and not bother
+ */
+TD.commonCase('wait for server greeting, inline CAPABILITY', function(T,RT) {
+  cannedConnectTest(T, RT, {
+    greeting: DOVECOT_CAPABILITY_GREETING,
+    firstRequest: LOGIN_REQUEST,
+    capabilities: DOVECOT_CAPABILITIES
+  });
 });
 
 }); // end define

--- a/test/unit/test_incoming_prober.js
+++ b/test/unit/test_incoming_prober.js
@@ -52,8 +52,7 @@ function proberClass(RT) {
 
 function openResponse(RT) {
   if (RT.envOptions.type === "imap") {
-    return '* OK [CAPABILITY IMAP4rev1 LITERAL+ SASL-IR LOGIN-REFERRALS ID' +
-           ' ENABLE IDLE STARTTLS AUTH=PLAIN] Dovecot ready.\r\n';
+    return '* OK IMAP rules, POP3 drools\r\n';
   } else if (RT.envOptions.type === "pop3") {
     return '+OK POP3 READY\r\n';
   }
@@ -166,7 +165,7 @@ TD.commonCase('STARTTLS unsupported', function(T, RT) {
       HOST, cci.connInfo.port,
       {
         cmd: 'fake',
-        data: openResponse(RT).replace('STARTTLS ', ''),
+        data: openResponse(RT)
       },
       precommands);
     eCheck.expect_namedValue('incoming:setTimeout', proberTimeout(RT));
@@ -464,7 +463,7 @@ function cannedLoginTest(T, RT, opts) {
       });
     } else { // IMAP
       precommands.push({
-          match: true,
+          match: /CAPABILITY/,
           actions: [
             {
               cmd: 'fake-receive',


### PR DESCRIPTION
isReady was sortof doing the greeting check previously, but it wasn't actually used for anything, so I removed it.
