### PR TITLE
Bug 983167 - [email/POP3] broken node-crypto.js shim causes auth failure...

### DIFF
--- a/data/lib/node-crypto.js
+++ b/data/lib/node-crypto.js
@@ -8,6 +8,7 @@ exports.createHash = function(algorithm) {
   return {
     update: function(addData) {
       data += addData;
+      return this;
     },
     digest: function(encoding) {
       switch (encoding) {


### PR DESCRIPTION
... when attempting APOP auth
