### PR TITLE
Bug 1039007 - [email/backend] Do not invoke operation callbacks until after any associated saves have safely hit the disk

### DIFF
--- a/data/lib/mailapi/mailuniverse.js
+++ b/data/lib/mailapi/mailuniverse.js
@@ -445,20 +445,28 @@ function MailUniverse(callAfterBigBang, online, testOptions) {
 
       // - Try to re-create any accounts using old account infos.
       if (lazyCarryover) {
-        self._LOG.configMigrating(lazyCarryover);
+        this._LOG.configMigrating_begin(lazyCarryover);
         var waitingCount = lazyCarryover.accountInfos.length;
         var oldVersion = lazyCarryover.oldVersion;
+
+        var accountRecreated = function(accountInfo, err) {
+          this._LOG.recreateAccount_end(accountInfo.type, accountInfo.id, err);
+          // We don't care how they turn out, just that they get a chance
+          // to run to completion before we call our bootstrap complete.
+          if (--waitingCount === 0) {
+            this._LOG.configMigrating_end(null);
+            this._initFromConfig();
+            callAfterBigBang();
+          }
+        };
+
         for (i = 0; i < lazyCarryover.accountInfos.length; i++) {
           var accountInfo = lazyCarryover.accountInfos[i];
-          $acctcommon.recreateAccount(self, oldVersion, accountInfo,
-                                      function() {
-            // We don't care how they turn out, just that they get a chance
-            // to run to completion before we call our bootstrap complete.
-            if (--waitingCount === 0) {
-              self._initFromConfig();
-              callAfterBigBang();
-            }
-          });
+          this._LOG.recreateAccount_begin(accountInfo.type, accountInfo.id,
+                                          null);
+          $acctcommon.recreateAccount(
+            self, oldVersion, accountInfo,
+            accountRecreated.bind(this, accountInfo));
         }
         // Do not let callAfterBigBang get called.
         return;
@@ -469,7 +477,7 @@ function MailUniverse(callAfterBigBang, online, testOptions) {
     }
     self._initFromConfig();
     callAfterBigBang();
-  });
+  }.bind(this));
 }
 exports.MailUniverse = MailUniverse;
 MailUniverse.prototype = {
@@ -1117,6 +1125,11 @@ MailUniverse.prototype = {
     }
   },
 
+  /**
+   * A local op finished; figure out what the error means, perform any requested
+   * saves, and *only after the saves complete*, issue any appropriate callback
+   * and only then start the next op.
+   */
   _localOpCompleted: function(account, op, err, resultIfAny,
                               accountSaveSuggested) {
 
@@ -1177,30 +1190,30 @@ MailUniverse.prototype = {
     }
     localQueue.shift();
 
+    var callback;
     if (completeOp) {
       if (this._opCallbacks.hasOwnProperty(op.longtermId)) {
-        var callback = this._opCallbacks[op.longtermId];
+        callback = this._opCallbacks[op.longtermId];
         delete this._opCallbacks[op.longtermId];
-        try {
-          callback(err, resultIfAny, account, op);
-        }
-        catch(ex) {
-          console.log(ex.message, ex.stack);
-          this._LOG.opCallbackErr(op.type);
-        }
       }
     }
 
     if (accountSaveSuggested) {
-      account.saveAccountState(null, this._startNextOp.bind(this, account),
-                               'localOp');
+      account.saveAccountState(
+        null,
+        this._startNextOp.bind(this, account, callback, op, err, resultIfAny),
+        'localOp:' + op.type);
       return;
     }
 
-    this._startNextOp(account);
+    this._startNextOp(account, callback, op, err, resultIfAny);
   },
 
   /**
+   * A server op finished; figure out what the error means, perform any
+   * requested saves, and *only after the saves complete*, issue any appropriate
+   * callback and only then start the next op.
+   *
    * @args[
    *   @param[account[
    *   @param[op]{
@@ -1385,49 +1398,68 @@ MailUniverse.prototype = {
     if (accountSaveSuggested)
       account._saveAccountIsImminent = true;
 
+    var callback;
     if (completeOp) {
       if (this._opCallbacks.hasOwnProperty(op.longtermId)) {
-        var callback = this._opCallbacks[op.longtermId];
+        callback = this._opCallbacks[op.longtermId];
         delete this._opCallbacks[op.longtermId];
-        try {
-          callback(err, resultIfAny, account, op);
-        }
-        catch(ex) {
-          console.log(ex.message, ex.stack);
-          this._LOG.opCallbackErr(op.type);
-        }
       }
 
       // This is a suggestion; in the event of high-throughput on operations,
       // we probably don't want to save the account every tick, etc.
       if (accountSaveSuggested) {
         account._saveAccountIsImminent = false;
-        account.saveAccountState(null, this._startNextOp.bind(this, account),
-                                'serverOp');
+        account.saveAccountState(
+          null,
+          this._startNextOp.bind(this, account, callback, op, err, resultIfAny),
+          'serverOp:' + op.type);
         return;
       }
     }
 
-    this._startNextOp(account)
+    this._startNextOp(account, callback, op, err, resultIfAny);
   },
 
   /**
    * Shared code for _localOpCompleted and _serverOpCompleted to figure out what
-   * to do next *after* any account save has completed.  It used to be that we
-   * would trigger saves without waiting for them to complete with the theory
-   * that this would allow us to generally be more efficient without losing
-   * correctness since the IndexedDB transaction model is strong and takes care
-   * of data dependency issues for us.  However, for both testing purposes and
-   * with some new concerns over correctness issues, it's now making sense to
-   * wait on the transaction to commit.  There are potentially some memory-use
-   * wins from waiting for the transaction to complete, especially if we
-   * imagine some particularly pathological situations.
+   * to do next *after* any account save has completed, including invoking
+   * callbacks.  See bug https://bugzil.la/1039007 for rationale as to why we
+   * think it makes sense to defer the callbacks or to provide new reasons why
+   * we should change this behaviour.
+   *
+   * It used to be that we would trigger saves without waiting for them to
+   * complete with the theory that this would allow us to generally be more
+   * efficient without losing correctness since the IndexedDB transaction model
+   * is strong and takes care of data dependency issues for us.  However, for
+   * both testing purposes and with some new concerns over correctness issues,
+   * it's now making sense to wait on the transaction to commit.  There are
+   * potentially some memory-use wins from waiting for the transaction to
+   * complete, especially if we imagine some particularly pathological
+   * situations.
+   *
+   * @param account
+   * @param {Function} [callback]
+   *   The callback associated with the last operation.  May be omitted.  If
+   *    provided then all of the following arguments must also be provided.
+   * @param [lastOp]
+   * @param [err]
+   * @param [result]
    */
-  _startNextOp: function(account, queues) {
+  _startNextOp: function(account, callback, lastOp, err, result) {
     var queues = this._opsByAccount[account.id],
         serverQueue = queues.server,
         localQueue = queues.local;
     var op;
+
+    if (callback) {
+      try {
+        callback(err, result, account, lastOp);
+      }
+      catch(ex) {
+        console.log(ex.message, ex.stack);
+        this._LOG.opCallbackErr(lastOp.type);
+      }
+    }
 
     // We must hold off on freeing up queue.active until after we have
     // completed processing and called the callback, just as we do in
@@ -1841,7 +1873,8 @@ MailUniverse.prototype = {
         folderId: folderId,
         headerInfo: sentSafeHeader,
         bodyInfo: sentSafeBody
-      });
+      },
+      callback);
     return [longtermId];
   },
 
@@ -2177,7 +2210,6 @@ var LOGFAB = exports.LOGFAB = $log.register($module, {
     type: $log.ACCOUNT,
     events: {
       configCreated: {},
-      configMigrating: {},
       configLoaded: {},
       createAccount: { type: true, id: false },
       reportProblem: { type: true, suppressed: true, id: false },
@@ -2194,6 +2226,8 @@ var LOGFAB = exports.LOGFAB = $log.register($module, {
       createAccount: { name: false },
     },
     asyncJobs: {
+      configMigrating: {},
+      recreateAccount: { type: true, id: false, err: false },
       saveUniverseState: {}
     },
     errors: {

--- a/test/unit/test_account_logic.js
+++ b/test/unit/test_account_logic.js
@@ -200,7 +200,7 @@ TD.commonCase('create a second (unique) account', function(T, RT) {
 
 TD.commonCase('try to create a duplicate account', function(T, RT) {
   var TEST_PARAMS = RT.envOptions;
-  var testUniverse = T.actor('testUniverse', 'U'),
+  var testUniverse = T.actor('testUniverse', 'U', { restored: true }),
       eSync = T.lazyLogger('sync');
   T.action('create account', testUniverse, eSync, function(T) {
     eSync.expect_namedValue('account-creation-error', 'user-account-exists');

--- a/test/unit/test_imap_bad_servers.js
+++ b/test/unit/test_imap_bad_servers.js
@@ -82,7 +82,7 @@ TD.commonCase('blacklist broken SPECIAL-USE implementation', function(T, RT) {
 TD.commonCase('use working SPECIAL-USE implementation', function(T, RT) {
   T.group('setup');
   var testUniverse =
-        T.actor('testUniverse', 'U'),
+        T.actor('testUniverse', 'U', { restored: true }),
       testAccount =
         T.actor('testAccount', 'B',
                 {

--- a/test/unit/test_linkify.js
+++ b/test/unit/test_linkify.js
@@ -712,7 +712,7 @@ TD.commonCase('linkify plaintext', function(T, RT) {
  */
 TD.commonCase('linkify HTML', function(T, RT) {
   // We need a universe to get a MailAPI
-  var testUniverse = T.actor('testUniverse', 'U'),
+  var testUniverse = T.actor('testUniverse', 'U', { restored: true }),
       eLazy = T.lazyLogger('linkCheck');
 
   function traverseAndLogExpectations(enodes) {

--- a/test/unit/test_mailapi_contacts.js
+++ b/test/unit/test_mailapi_contacts.js
@@ -113,7 +113,7 @@ TD.commonCase('get DOMStrings not DOMStringLists', function(T, RT) {
  */
 TD.commonCase('do not die on empty names', function(T, RT) {
   T.group('setup');
-  var testUniverse = T.actor('testUniverse', 'U'),
+  var testUniverse = T.actor('testUniverse', 'U', { restored: true }),
       testContacts = T.actor('testContacts', 'contacts'),
       eCheck = T.lazyLogger('check');
   var ContactCache = $mailapi.ContactCache;
@@ -188,7 +188,7 @@ TD.commonCase('do not die on empty names', function(T, RT) {
 TD.commonCase('bounded cache size', function(T, RT) {
   T.group('setup');
   var TEST_PARAMS = RT.envOptions;
-  var testUniverse = T.actor('testUniverse', 'U'),
+  var testUniverse = T.actor('testUniverse', 'U', { restored: true }),
       testContacts = T.actor('testContacts', 'contacts'),
       eCheck = T.lazyLogger('check');
   var ContactCache = $mailapi.ContactCache;
@@ -385,7 +385,7 @@ TD.commonCase('bounded cache size', function(T, RT) {
 TD.commonCase('oncontactchange processing', function(T, RT) {
   T.group('setup');
   var TEST_PARAMS = RT.envOptions;
-  var testUniverse = T.actor('testUniverse', 'U'),
+  var testUniverse = T.actor('testUniverse', 'U', { restored: true }),
       testContacts = T.actor('testContacts', 'contacts'),
       eCheck = T.lazyLogger('check');
   var ContactCache = $mailapi.ContactCache;
@@ -611,7 +611,7 @@ TD.commonCase('oncontactchange processing', function(T, RT) {
 TD.commonCase('live peep tracking', function(T, RT) {
   T.group('setup');
   var TEST_PARAMS = RT.envOptions;
-  var testUniverse = T.actor('testUniverse', 'U'),
+  var testUniverse = T.actor('testUniverse', 'U', { restored: true }),
       testAccount = T.actor('testAccount', 'A',
                             { universe: testUniverse }),
       testContacts = T.actor('testContacts', 'contacts'),


### PR DESCRIPTION
The core of this is the save change.  This also exacerbated an intermittent
failure in test_activesync_recreate so I cleaned that up a little which
involved adding some more logging in this area.  (Well, I probably could
have gotten by without the extra logging, but I believe we are imminently
going to improve our upgrade mechanism, and that will want the logging, so
here we are.)
