### PR TITLE
Bug 1091295 - [Email] Failure to normalize newlines in composed messages. May cause some SMTP servers (ex: qmail) to refuse to send mail with a 451 error.

### DIFF
--- a/js/smtp/client.js
+++ b/js/smtp/client.js
@@ -288,6 +288,7 @@ define(function(require, exports) {
       normalizedError: normalizedError,
       errorName: err.name,
       errorMessage: err.message,
+      errorData: err.data,
       wasSending: wasSending
     });
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "argparse": "~0.1.15",
     "js-yaml": "~3.2.2",
-    "mail-fakeservers": "~0.0.29",
+    "mail-fakeservers": "0.0.30",
     "mozilla-download": "~0.4",
     "ms": "~0.6.2",
     "mustache": "~0.8.2",


### PR DESCRIPTION
Note that r+-ing this is an implicit r+ of
https://github.com/mozilla-b2g/mail-fakeservers/pull/24
which I have speculatively already landed.  In that vein, note that I've also
updated our package.json to NOT use a tilde for mail-fakeservers since the
tilde regrettably defeats my whole concept of "we don't take the upgrade
without a gelam upgrade".
