### PR TITLE
Bug 1116694 - [email/IMAP] moves broken on servers without UIDNEXT support, such as all CoreMail servers (ex: 126.com, 163.com)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
       "browserbox": "github:whiteout-io/browserbox/v0.5.2",
       "utf7": "github:whiteout-io/utf7/v2.0.2",
-      "imap-handler": "github:whiteout-io/imap-handler/v0.1.13",
+      "imap-handler": "github:whiteout-io/imap-handler/3b54101d43925a17c793d7f02d555d6e0c1144c2",
       "mimefuncs": "github:whiteout-io/mimefuncs/v0.3.9",
       "axe": "github:whiteout-io/axe/v0.0.2",
       "smtpclient": "github:whiteout-io/smtpclient/v0.5.1",

--- a/test-runner/chrome/content/loggest-chrome-runner.js
+++ b/test-runner/chrome/content/loggest-chrome-runner.js
@@ -889,6 +889,9 @@ function _runTestFile(runner, testFileName, variant, baseUrl, manifestUrl,
   var testParams;
   switch (variant) {
     case 'imap:fake':
+    // fakeserver variants
+    case 'imap:fake:nouidnext':
+    case 'imap:fake:no_internaldate_tz':
       testParams = {
         name: 'Baron von Testendude',
         emailAddress: 'testy@fakeimaphost',
@@ -901,6 +904,14 @@ function _runTestFile(runner, testFileName, variant, baseUrl, manifestUrl,
 
         controlServerBaseUrl: controlServer.baseUrl,
       };
+      switch (variant) {
+        case 'imap:fake:nouidnext':
+          testParams.imapExtensions = ['NOUIDNEXT'];
+          break;
+        case 'imap:fake:no_internaldate_tz':
+          testParams.imapExtensions = ['NO_INTERNALDATE_TZ'];
+          break;
+      }
       break;
     case 'pop3:fake':
       testParams = {
@@ -938,10 +949,10 @@ function _runTestFile(runner, testFileName, variant, baseUrl, manifestUrl,
       testParams = TEST_PARAMS;
       break;
     case 'imap:noserver':
-      testParams = {type: 'imap'};
+      testParams = { type: 'imap' };
       break;
     case 'pop3:noserver':
-      testParams = {type: 'pop3'};
+      testParams = { type: 'pop3' };
       break;
     case 'script':
       testParams = SCRIPT_PARAMS;

--- a/test/test-files.json
+++ b/test/test-files.json
@@ -21,6 +21,14 @@
       "desc": "IMAP tests against our fake-server",
       "optional": false
     },
+    "imap:fake:nouidnext": {
+      "desc": "jerky IMAP fake-server that never provides UIDNEXT on SELECT/EXAMINE",
+      "optional": false
+    },
+    "imap:fake:no_internaldate_tz": {
+      "desc": "jerky IMAP fake-server that does not include a timezone in its INTERNALDATE values.  (the +000 part)",
+      "optional": false
+    },
     "imap:real": {
       "desc": "IMAP tests against a real server",
       "optional": true
@@ -53,11 +61,11 @@
     },
 
     "test_imap_complex.js": {
-      "variants": ["imap:fake", "imap:real"]
+      "variants": ["imap:fake", "imap:fake:nouidnext", "imap:real"]
     },
 
     "test_imap_general.js": {
-      "variants": ["imap:fake", "imap:real"]
+      "variants": ["imap:fake", "imap:fake:nouidnext", "imap:real"]
     },
 
     "test_imap_oauth.js": {
@@ -81,7 +89,7 @@
     },
 
     "test_imap_internals.js": {
-      "variants": ["imap:fake", "imap:real"]
+      "variants": ["imap:fake", "imap:fake:nouidnext", "imap:real"]
     },
 
     "test_imap_create_folders.js": {
@@ -113,7 +121,7 @@
     },
 
     "test_imap_internaldate_no_tz.js": {
-      "variants": ["imap:fake"]
+      "variants": ["imap:fake:no_internaldate_tz"]
     },
 
     "test_incoming_prober.js": {
@@ -125,7 +133,7 @@
     },
 
     "test_incoming_imap_tz_prober.js": {
-      "variants": ["imap:fake"]
+      "variants": ["imap:fake:nouidnext"]
     },
 
     "test_incoming_pop3_prober.js": {
@@ -238,7 +246,7 @@
     },
 
     "test_mutation.js": {
-      "variants": ["imap:fake", "imap:real", "activesync:fake", "pop3:fake"]
+      "variants": ["imap:fake", "imap:fake:nouidnext", "imap:real", "activesync:fake", "pop3:fake"]
     },
 
     "test_sync_server_changes.js": {

--- a/test/unit/resources/th_fake_imap_server.js
+++ b/test/unit/resources/th_fake_imap_server.js
@@ -77,7 +77,12 @@ var TestFakeIMAPServerMixins = {
 
       var TEST_PARAMS = self.RT.envOptions, serverInfo;
 
-      var imapExtensions = opts.imapExtensions || ['RFC2195'];
+      // The specific test always wins, but if not specified, we leave it up to
+      // the test variant.
+      var imapExtensions = self.imapExtensions =
+            opts.imapExtensions ||
+            TEST_PARAMS.imapExtensions ||
+            ['RFC2195'];
 
       if (!serverExists) {
         // talk to the control server to get it to create our server

--- a/test/unit/test_imap_internaldate_no_tz.js
+++ b/test/unit/test_imap_internaldate_no_tz.js
@@ -25,6 +25,15 @@ TD.commonCase('basic sync succeeds', function(T, RT) {
       imapExtensions: ['NO_INTERNALDATE_TZ']
     });
 
+  // Make sure that our test infrastructure is properly running this test
+  T.check('ensure server variant', function() {
+    if (testAccount.testServer.imapExtensions.indexOf('NO_INTERNALDATE_TZ') ===
+        -1) {
+      throw new Error(
+        'This test demands that the server be NO_INTERNALDATE_TZ');
+    }
+  });
+
   T.group('sync');
   var saturatedFolder = testAccount.do_createTestFolder(
     'test_internaldate_no_tz',


### PR DESCRIPTION
We:
- Have the test variants imply specific fake-server configurations so that
  we can easily have all the IMAP tests run under a variety of fake-server
  configurations.
- Make the move operation fall back to using message sequence numbers
  instead of the UID while trying to find out the new message's UID.  This
  is the same thing we do for the IMAP prober which was the other place we
  had a UIDNEXT problem.

Testing-wise:
- I verified the test_mutation tests fail without the fix when using the
  nouidnext fake-server variant.
- I changed the existing tests that used the imapExtensions mechanism as
  part of their test to instead use the new test variants.  To make sure
  I didn't screw this up, I had the 2 existing tests add a check to
  ensure they were seeing the expected imapExtensions.  Note that at least
  the prober test has other safe-guards to ensure the right path is used,
  since I did in fact make a refactoring dumb mistake and this wasn't
  entirely working to begin with!