### PR TITLE
Bug 1116728 - [Flame][Email]When sending email to several recipients whose addresses are separated by semicolon, the email can’t be sent successfully. r=andris9

### DIFF
--- a/js/ext/addressparser.js
+++ b/js/ext/addressparser.js
@@ -237,7 +237,15 @@
         "(": ")",
         "<": ">",
         ",": "",
-        ":": ";"
+        // Groups are ended by semicolons
+        ":": ";",
+        // Semicolons are not a legal delimiter per the RFC2822 grammar other
+        // than for terminating a group, but they are also not valid for any
+        // other use in this context.  Given that some mail clients have
+        // historically allowed the semicolon as a delimiter equivalent to the
+        // comma in their UI, it makes sense to treat them the same as a comma
+        // when used outside of a group.
+        ";": ""
     };
 
     /**

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
       "mailbuild": "github:whiteout-io/mailbuild/v0.3.7",
       "browserbox-imap": "github:whiteout-io/browserbox/v0.4.0#src/browserbox-imap.js",
       "mimeparser-tzabbr": "github:whiteout-io/mimeparser/v0.3.8#src/mimeparser-tzabbr.js",
-      "addressparser": "github:whiteout-io/addressparser/v0.1.3",
+      "addressparser": "github:whiteout-io/addressparser/e5c9c0c985caa5a740cd7863370929e3e1611077",
       "mimetypes": "github:whiteout-io/mimetypes/v0.1.1",
       "punycode": "github:bestiejs/punycode.js/v1.2.4"
     }


### PR DESCRIPTION
Land https://github.com/whiteout-io/addressparser/pull/5 using the
merge commit.  Tests are in upstream.