### PR TITLE
Bug 1120875 - Improved mem usage for fromTypedArray. r=andris9, r=asuth

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
       "browserbox": "github:whiteout-io/browserbox/v0.5.2",
       "utf7": "github:whiteout-io/utf7/v2.0.2",
       "imap-handler": "github:whiteout-io/imap-handler/3b54101d43925a17c793d7f02d555d6e0c1144c2",
-      "mimefuncs": "github:whiteout-io/mimefuncs/v0.3.9",
+      "mimefuncs": "github:whiteout-io/mimefuncs/e37b8f7d976d83d6ae126a33c1b9adeef880332a",
       "axe": "github:whiteout-io/axe/v0.0.2",
       "smtpclient": "github:whiteout-io/smtpclient/v0.5.1",
       "mimeparser": "github:whiteout-io/mimeparser/v0.3.8",


### PR DESCRIPTION
This is primarily to land my patch (that is r=andris9 in upstream):
https://github.com/whiteout-io/mimefuncs/pull/10

But this also gets us the contents of the mimefuncs PR 9 which included
improved TextDecoder fallback logic.  r=asuth on us taking those changes.