### PR TITLE
Bug 1107749 - fix unread count logic

### DIFF
--- a/js/jobmixins.js
+++ b/js/jobmixins.js
@@ -34,6 +34,7 @@ exports.local_do_modtags = function(op, doneCallback, undo) {
   var self = this;
   var addTags = undo ? op.removeTags : op.addTags,
       removeTags = undo ? op.addTags : op.removeTags;
+  var mutationsPerformed = 0;
   this._partitionAndAccessFoldersSequentially(
     op.messages,
     false,
@@ -49,15 +50,16 @@ exports.local_do_modtags = function(op, doneCallback, undo) {
         if (addTags) {
           for (iTag = 0; iTag < addTags.length; iTag++) {
             tag = addTags[iTag];
-            if (tag === '\\Seen') {
-              storage.folderMeta.unreadCount--;
-            }
             // The list should be small enough that native stuff is better
             // than JS bsearch.
             existing = header.flags.indexOf(tag);
             if (existing !== -1)
               continue;
             header.flags.push(tag);
+            mutationsPerformed++;
+            if (tag === '\\Seen') {
+              storage.folderMeta.unreadCount--;
+            }
             header.flags.sort(); // (maintain sorted invariant)
             modified = true;
           }
@@ -65,13 +67,14 @@ exports.local_do_modtags = function(op, doneCallback, undo) {
         if (removeTags) {
           for (iTag = 0; iTag < removeTags.length; iTag++) {
             tag = removeTags[iTag];
-            if (tag === '\\Seen') {
-              storage.folderMeta.unreadCount++;
-            }
             existing = header.flags.indexOf(tag);
             if (existing === -1)
               continue;
             header.flags.splice(existing, 1);
+            mutationsPerformed++;
+            if (tag === '\\Seen') {
+              storage.folderMeta.unreadCount++;
+            }
             modified = true;
           }
         }
@@ -80,6 +83,18 @@ exports.local_do_modtags = function(op, doneCallback, undo) {
       }
     },
     function() {
+      // If we didn't actually do anything, then we don't actually need to do
+      // anything on the server either and we can skip it.
+      //
+      // Note that this does get us into some edge cases around the semantics of
+      // undo.  Before this change, "undo" always just meant "do the opposite
+      // modification of what I said" which is notably different from "undo the
+      // things you actually just did" which gave rise to the (currently
+      // unfixed) https://bugzil.la/997496.  And so with this change, we'll do
+      // the "right" thing, but in other cases we'll still do the "wrong" thing.
+      if (mutationsPerformed === 0) {
+        op.serverStatus = 'skip';
+      }
       doneCallback(null, null, true);
     },
     null, // connection loss does not happen for local-only ops

--- a/js/mailslice.js
+++ b/js/mailslice.js
@@ -507,7 +507,14 @@ MailSlice.prototype = {
 };
 
 
-var FOLDER_DB_VERSION = exports.FOLDER_DB_VERSION = 2;
+/**
+ * Folder version history:
+ *
+ * v3: Unread count tracking fixed, so we need to re-run it.
+ *
+ * v2: Initial unread count tracking.  Regrettably with bad maths.
+ */
+var FOLDER_DB_VERSION = exports.FOLDER_DB_VERSION = 3;
 
 /**
  * Per-folder message caching/storage; issues per-folder `MailSlice`s and keeps


### PR DESCRIPTION
We were messing with the unread count even if a \Seen modification
turned out to be a no-op.  Which is very wrong.  So this patch:
- Has us not mess with the count in the no-op cases
- Adds logic to cause us to skip the "server" op if it ends up
  everything in the job was a no-op.  This provides a slight
  slight improvement in undo semantics but does not fix the known bug
  on that.
- Adds test cases for these unread cases.
- Bumps the folder DB version to force us to recompute the unread
  count.