### PR TITLE
Bug 1094632 - Fix attachment icon not showing in local draft

### DIFF
--- a/js/drafts/draft_rep.js
+++ b/js/drafts/draft_rep.js
@@ -47,7 +47,7 @@ function mergeDraftStates(oldHeader, oldBody,
     replyTo: identity.replyTo,
     date: newDraftInfo.date,
     flags: [],
-    hasAttachments: oldHeader ? oldHeader.hasAttachments : false,
+    hasAttachments: oldBody ? oldBody.attachments.length > 0 : false,
     subject: newDraftRep.subject,
     snippet: newDraftRep.body.text.substring(0, 100),
   });

--- a/test/unit/test_compose_detach.js
+++ b/test/unit/test_compose_detach.js
@@ -157,6 +157,18 @@ TD.commonCase('detach attachments', function(T, RT) {
   }
   helpCloseComposition();
 
+  T.group('verify draft header after attach');
+  function helpVerifyHeader() {
+    T.check(eLazy, 'verify draft header after attach', function() {
+      var draftHeader = localDraftsView.slice.items[0];
+      eLazy.expect_namedValueD('header has attachments', true);
+      eLazy.namedValueD('header has attachments',
+                        draftHeader.hasAttachments,
+                        draftHeader);
+    });
+  }
+  helpVerifyHeader();
+
   T.group('reopen draft');
   function helpReopenComposition(numDraftsExpected) {
     T.action(eLazy, 'reopen composition', function() {


### PR DESCRIPTION
In bug 1094632 local draft will not have proper header indicates
there's attachment inside the draft. This patch fixes it and add
unit test on it.