### PR TITLE
Bug 1128285 - Avoid snippet fetch hang by not leaking latches

### DIFF
--- a/js/imap/folder.js
+++ b/js/imap/folder.js
@@ -743,14 +743,6 @@ ImapFolderConn.prototype = {
         if (rep.isDownloaded)
           return;
 
-        var request = {
-          uid: header.srvid,
-          partInfo: rep._partInfo,
-          bodyRepIndex: idx,
-          createSnippet: idx === bodyRepIdx,
-          headerUpdatedCallback: latch.defer(header.srvid + '-' + rep._partInfo)
-        };
-
         // default to the entire remaining email. We use the estimate * largish
         // multiplier so even if the size estimate is wrong we should fetch more
         // then the requested number of bytes which if truncated indicates the
@@ -783,6 +775,19 @@ ImapFolderConn.prototype = {
         // network request than breaking here.
         if (bytesToFetch <= 0)
           bytesToFetch = 64;
+
+        // CONDITIONAL LOGIC BARRIER CONDITIONAL LOGIC BARRIER DITTO DITTO
+        // Do not do return/continue after this point because we call
+        // latch.defer below, and we break if we call it and then throw away
+        // that callback without calling it.  (Unsurprisingly.)
+
+        var request = {
+          uid: header.srvid,
+          partInfo: rep._partInfo,
+          bodyRepIndex: idx,
+          createSnippet: idx === bodyRepIdx,
+          headerUpdatedCallback: latch.defer(header.srvid + '-' + rep._partInfo)
+        };
 
         // we may only need a subset of the total number of bytes.
         if (overallMaximumBytes !== undefined || rep.amountDownloaded) {

--- a/test/unit/test_imap_parallelfetch.js
+++ b/test/unit/test_imap_parallelfetch.js
@@ -28,7 +28,10 @@ TD.commonCase('fetch N body snippets at once', function(T, RT) {
                             { universe: testUniverse,
                               realAccountNeeded: true });
 
-  var eLazy = T.lazyLogger('misc');
+  // To improve logging visibility, use a separate lazy logger for each.
+  var eSnippet = T.lazyLogger('snippet'),
+      eBody = T.lazyLogger('body');
+
   var folderName = 'test_imap_parallel_fetch';
   var messageCount = 22;
 
@@ -39,15 +42,39 @@ TD.commonCase('fetch N body snippets at once', function(T, RT) {
       SyntheticPartMultiSignedSMIME = $msggen.SyntheticPartMultiSignedSMIME;
 
 
+  // Build a sufficiently large text part that the snippeting logic won't
+  // download the entire body part.  Since we currently use 4k everywhere,
+  // but in some cases will double to go up to 8k if that gets the whole
+  // thing, make sure we are over 8k.
+  var hugeText, textLines = [];
+  for (var iHuge = 0; iHuge < (8192 / 64) + 1; iHuge++) {
+    textLines.push('abcdefghijklmnopqrstuvwxyz' + // 26
+                   'ABCDEFGHIJKLMNOPQRSTUVWXYZ' + // 26 => 52
+                   '0123456789'); // 10 + (\r\n) 2 = 12 => 64
+  }
+  // Note that we only use \n but messageGenerator will expand it out to be
+  // \r\n.  We do this because our backend only uses \n when it reports things
+  // to us.
+  hugeText = textLines.join('\n');
+
   var partText = new SyntheticPartLeaf("I am text! Woo!");
+  var partHugeText = new SyntheticPartLeaf(hugeText);
   var partHtml = new SyntheticPartLeaf(
     "<html><head></head><body>I am HTML! Woo! </body></html>",
     {
       contentType: "text/html"
     }
   );
+  var partHugeHtml = new SyntheticPartLeaf(
+    "<html><head></head><body>" + hugeText + "</body></html>",
+    {
+      contentType: "text/html"
+    }
+  );
   var sanitizedHtmlStr = 'I am HTML! Woo!';
   var partAlternative = new SyntheticPartMultiAlternative([partText, partHtml]);
+  var partHugeAlternative = new SyntheticPartMultiAlternative(
+                              [partHugeText, partHugeHtml]);
   var mailingListFooterContent = 'I am an annoying footer!';
   var partMailingListFooter = new SyntheticPartLeaf(mailingListFooterContent);
   var relImage = {contentType: 'image/png',
@@ -79,6 +106,26 @@ TD.commonCase('fetch N body snippets at once', function(T, RT) {
           [partText, new SyntheticPartMultiRelated([partHtml, partRelImage])]),
       bodyStr: sanitizedHtmlStr,
       expectedContents: [sanitizedHtmlStr]
+    },
+    // - mailing-list style mixed alternative (html or text) with list footer
+    // in this one, we expect our snippet fetch to fetch both body parts
+    {
+      name: 'mailing list with 2 small body parts',
+      bodyPart: new SyntheticPartMultiMixed(
+        [partAlternative,
+         partMailingListFooter]),
+      bodyStr: sanitizedHtmlStr,
+      expectedContents: [sanitizedHtmlStr, mailingListFooterContent]
+    },
+    // in this one, the first body part is big enough that we won't fetch the
+    // footer.
+    {
+      name: 'mailing list with 1 big and 1 small body part',
+      bodyPart: new SyntheticPartMultiMixed(
+        [partHugeAlternative,
+         partMailingListFooter]),
+      bodyStr: hugeText,
+      expectedContents: [hugeText, mailingListFooterContent]
     },
     // - S/MIME derived complex hierarchy (complex hierarchy!)
     {
@@ -118,11 +165,13 @@ TD.commonCase('fetch N body snippets at once', function(T, RT) {
 
   var imapSocket;
 
-  T.group('recieving data');
+  T.group('receiving data');
 
-  T.action('recieve fetches in random order', eLazy, function() {
-    // we don't care about order only correctness
-    eLazy.expectUseSetMatching();
+  T.action('recieve fetches in random order', eSnippet, eBody, function() {
+    // The order is defined to be random, and by golly, it sure comes out
+    // random!
+    eSnippet.expectUseSetMatching();
+    eBody.expectUseSetMatching();
 
     folderView.slice.items.forEach(function(header) {
       var serverMsg = testFolder.findServerMessage(header.guid);
@@ -133,13 +182,14 @@ TD.commonCase('fetch N body snippets at once', function(T, RT) {
         throw new Error('no server content for guid: ' + header.guid);
       var snippet = snippetBodyRepContent.slice(0, 20);
 
-      eLazy.expect_namedValue('snippet', {
+      eSnippet.expect_namedValue(header.id, {
         id: header.id,
+        name: msgDef.name,
         // snippets are usually trimmed
         approxSnippet: snippet.trim()
       });
 
-      eLazy.expect_namedValue('bodyReps', {
+      eBody.expect_namedValue(header.id, {
         id: header.id,
         contents: msgDef.expectedContents,
         isDownloaded: true
@@ -158,7 +208,7 @@ TD.commonCase('fetch N body snippets at once', function(T, RT) {
           header.getBody({ withBodyReps: true }, function(body) {
             if (!body) {
               // ???!
-              eLazy.namedValue('missing body for header', header.id);
+              eBody.namedValue('missing body for header', header.id);
               return;
             }
 
@@ -167,7 +217,7 @@ TD.commonCase('fetch N body snippets at once', function(T, RT) {
                       item.content[1] : item.content).trim();
             });
 
-            eLazy.namedValue('bodyReps', {
+            eBody.namedValue(header.id, {
               id: header.id,
               contents: contents,
               isDownloaded: body.bodyReps[0].isDownloaded
@@ -176,15 +226,17 @@ TD.commonCase('fetch N body snippets at once', function(T, RT) {
             body.die();
           });
 
-          eLazy.namedValue('snippet', {
+          eSnippet.namedValue(header.id, {
             id: header.id,
+            name: msgDef.name,
             approxSnippet: header.snippet.slice(0, 20).trim()
           });
         }
       };
     });
 
-    folderView.slice.maybeRequestBodies(0, messageCount + 1);
+    folderView.slice.maybeRequestBodies(0, messageCount + 1,
+                                        { maximumBytesToFetch: 4096 });
   });
 
 });


### PR DESCRIPTION
Multipart bodies with N parts that we are interested in where the first N-1
body parts are sufficient to push us over our byte limit will result in us
creating and leaking allback latches for the succeeding parts.  This is
corrected by not creating the latch until we're sure we're going to try and
process the part.

This includes a fix and added test coverage in test_imap_parallelfetch that
fails without the fix.  I chose the specific test because it is specifically
a test of the snippet logic and intentionally tries to do things in parallel.
As such, it's the best place to also try and force a hang due to weird
concurrency.

(The other place I was considering to put the test was test_mime which also
has various MIME hierarchy permutations and snippet-checking logic.  However,
test_mime is more concerned about the correctness of consuming the various
structures rather than the mechanics of how we go about fetching things from
the server.)