### PR TITLE
Bug 1098289 - Migrate Email to use navigator.sync (RequestSync) API (Phase1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,13 +74,22 @@ download-b2g: b2g
 gaia-symlink:
 	echo "You need to create a symlink 'gaia-symlink' pointing at the gaia dir"
 
+SYS=$(shell uname -s)
 B2GBD := b2g-builddir-symlink
 ifeq ($(wildcard b2g-bindir-symlink),)
-  B2GBIND := $(B2GBD)/dist/bin
-  RUNB2G := $(B2GBIND)/b2g
+	B2GBIND := $(B2GBD)/dist/bin
+	RUNB2G := $(B2GBIND)/b2g
 else
-  B2GBIND := b2g-bindir-symlink
-  RUNB2G := $(B2GBIND)/b2g-bin
+	# OS X has trouble launching the executable via the symlink, gets a "Couldn't
+	# load XPCOM" error, so resolve the symlink first. Do not generically use
+	# readlink on all platforms, since it behaves slightly differently, and only
+	# the OS X platform seems to exhibit this problem.
+	ifeq ($(SYS),Darwin)
+		B2GBIND=`readlink b2g-bindir-symlink`
+	else
+		B2GBIND := b2g-bindir-symlink
+	endif
+	RUNB2G := $(B2GBIND)/b2g-bin
 endif
 
 ARBPLD=arbpl-dir-symlink

--- a/js/main-frame-setup.js
+++ b/js/main-frame-setup.js
@@ -5,7 +5,7 @@
  * Main: Spawns worker
  * Worker: Loads core JS
  * Worker: 'hello' => main
- * Main: 'hello' => worker with online status and mozAlarms status
+ * Main: 'hello' => worker with online status and navigator.sync status
  * Worker: Creates MailUniverse
  * Worker 'mailbridge'.'hello' => main
  * Main: Creates MailAPI, sends event to UI

--- a/js/worker-support/cronsync-main.js
+++ b/js/worker-support/cronsync-main.js
@@ -9,15 +9,6 @@ define(function(require) {
     console.log('cronsync-main: ' + str);
   }
 
-  function makeData(accountIds, interval, date) {
-    return {
-      type: 'sync',
-      accountIds: accountIds,
-      interval: interval,
-      timestamp: date.getTime()
-    };
-  }
-
   // Creates a string key from an array of string IDs. Uses a space
   // separator since that cannot show up in an ID.
   function makeAccountKey(accountIds) {
@@ -33,8 +24,9 @@ define(function(require) {
 
   // Makes sure two arrays have the same values, account IDs.
   function hasSameValues(ary1, ary2) {
-    if (ary1.length !== ary2.length)
+    if (ary1.length !== ary2.length) {
       return false;
+    }
 
     var hasMismatch = ary1.some(function(item, i) {
       return item !== ary2[i];
@@ -44,13 +36,10 @@ define(function(require) {
   }
 
   if (navigator.mozSetMessageHandler) {
-    navigator.mozSetMessageHandler('alarm', function onAlarm(alarm) {
-      // Do not bother with alarms that are not sync alarms.
-      var data = alarm.data;
-      if (!data || data.type !== 'sync')
-        return;
-
-      // Need to acquire the wake locks during this alarm notification
+    navigator.mozSetMessageHandler('request-sync',
+    function onRequestSync(e) {
+      var data = e.data;
+      // Need to acquire the wake locks during this notification
       // turn of the event loop -- later turns are not guaranteed to
       // be up and running. However, knowing when to release the locks
       // is only known to the front end, so publish event about it.
@@ -72,7 +61,10 @@ define(function(require) {
                              makeAccountKey(data.accountIds), locks);
       }
 
-      dispatcher._sendMessage('alarm', [data.accountIds, data.interval]);
+      debug('request-sync started at ' + (new Date()));
+
+      dispatcher._sendMessage('requestSync',
+                              [data.accountIds, data.interval]);
     });
   }
 
@@ -103,161 +95,157 @@ define(function(require) {
     },
 
     /**
-     * Clears all sync-based alarms. Normally not called, except perhaps for
+     * Clears all sync-based tasks. Normally not called, except perhaps for
      * tests or debugging.
      */
     clearAll: function() {
-      var mozAlarms = navigator.mozAlarms;
-      if (!mozAlarms)
+      var navSync = navigator.sync;
+      if (!navSync) {
         return;
+      }
 
-      var r = mozAlarms.getAll();
-
-      r.onsuccess = function(event) {
-        var alarms = event.target.result;
-        if (!alarms)
+      navSync.registrations().then(function(registrations) {
+        if (!registrations.length) {
           return;
+        }
 
-        alarms.forEach(function(alarm) {
-          if (alarm.data && alarm.data.type === 'sync')
-            mozAlarms.remove(alarm.id);
+        registrations.forEach(function(registeredTask) {
+          navSync.unregister(registeredTask.task);
         });
-      }.bind(this);
-      r.onerror = function(err) {
-        console.error('cronsync-main clearAll mozAlarms.getAll: error: ' +
-                      err);
-      }.bind(this);
+      }.bind(this),
+      function(err) {
+        console.error('cronsync-main clearAll navigator.sync.registrations ' +
+                      'error: ' + err);
+      }.bind(this));
     },
 
     /**
-     * Makes sure there is an alarm set for every account in
+     * Makes sure there is an sync task set for every account in
      * the list.
      * @param  {Object} syncData. An object with keys that are
      * 'interval' + intervalInMilliseconds, and values are arrays
      * of account IDs that should be synced at that interval.
      */
     ensureSync: function (syncData) {
-      var mozAlarms = navigator.mozAlarms;
-      if (!mozAlarms) {
-        console.warn('no mozAlarms support!');
+      var navSync = navigator.sync;
+      if (!navSync) {
+        console.warn('no navigator.sync support!');
+        // Let backend know work has finished, even though it was a no-op.
+        this._sendMessage('syncEnsured');
         return;
       }
 
       debug('ensureSync called');
 
-      var request = mozAlarms.getAll();
-
-      request.onsuccess = function(event) {
+      navSync.registrations().then(function(registrations) {
         debug('success!');
 
-        var alarms = event.target.result;
-        // If there are no alarms a falsey value may be returned.  We want
-        // to not die and also make sure to signal we completed, so just make
-        // an empty list.
-        if (!alarms) {
-          alarms = [];
-        }
+        // Find all IDs being tracked by sync tasks
+        var expiredTasks = [],
+            okTaskIntervals = {},
+            uniqueTasks = {};
 
-        // Find all IDs being tracked by alarms
-        var expiredAlarmIds = [],
-            okAlarmIntervals = {},
-            uniqueAlarms = {};
-
-        alarms.forEach(function(alarm) {
-          // Only care about sync alarms.
-          if (!alarm.data || !alarm.data.type || alarm.data.type !== 'sync')
-            return;
-
-          var intervalKey = 'interval' + alarm.data.interval,
+        registrations.forEach(function(task) {
+          // minInterval in seconds, but use milliseconds for sync values
+          // internally.
+          var intervalKey = 'interval' + (task.minInterval * 1000),
               wantedAccountIds = syncData[intervalKey];
 
           if (!wantedAccountIds || !hasSameValues(wantedAccountIds,
-                                                  alarm.data.accountIds)) {
-            debug('account array mismatch, canceling existing alarm');
-            expiredAlarmIds.push(alarm.id);
+                                                  task.data.accountIds)) {
+            debug('account array mismatch, canceling existing sync task');
+            expiredTasks.push(task);
           } else {
-            // Confirm the existing alarm is still good.
+            // Confirm the existing sync task is still good.
             var interval = toInterval(intervalKey),
-                now = Date.now(),
-                alarmTime = alarm.data.timestamp,
                 accountKey = makeAccountKey(wantedAccountIds);
 
-            // If the interval is nonzero, and there is no other alarm found
+            // If the interval is nonzero, and there is no other task found
             // for that account combo, and if it is not in the past and if it
             // is not too far in the future, it is OK to keep.
-            if (interval && !uniqueAlarms.hasOwnProperty(accountKey) &&
-                alarmTime > now && alarmTime < now + interval) {
-              debug('existing alarm is OK');
-              uniqueAlarms[accountKey] = true;
-              okAlarmIntervals[intervalKey] = true;
+            if (interval && !uniqueTasks.hasOwnProperty(accountKey)) {
+              debug('existing sync task is OK: ' + interval);
+              uniqueTasks[accountKey] = true;
+              okTaskIntervals[intervalKey] = true;
             } else {
-              debug('existing alarm is out of interval range, canceling');
-              expiredAlarmIds.push(alarm.id);
+              debug('existing sync task is out of interval range, canceling');
+              expiredTasks.push(task);
             }
           }
         });
 
-        expiredAlarmIds.forEach(function(alarmId) {
-          mozAlarms.remove(alarmId);
+        expiredTasks.forEach(function(expiredTask) {
+          navSync.unregister(expiredTask.task);
         });
 
-        var alarmMax = 0,
-            alarmCount = 0,
+        var taskMax = 0,
+            taskCount = 0,
             self = this;
 
-        // Called when alarms are confirmed to be set.
+        // Called when sync tasks are confirmed to be set.
         function done() {
-          alarmCount += 1;
-          if (alarmCount < alarmMax)
+          taskCount += 1;
+          if (taskCount < taskMax) {
             return;
+          }
 
           debug('ensureSync completed');
           // Indicate ensureSync has completed because the
-          // back end is waiting to hear alarm was set before
-          // triggering sync complete.
+          // back end is waiting to hear sync task was set
+          // before triggering sync complete.
           self._sendMessage('syncEnsured');
         }
 
         Object.keys(syncData).forEach(function(intervalKey) {
-          // Skip if the existing alarm is already good.
-          if (okAlarmIntervals.hasOwnProperty(intervalKey))
+          // Skip if the existing sync task is already good.
+          if (okTaskIntervals.hasOwnProperty(intervalKey)) {
             return;
+          }
 
           var interval = toInterval(intervalKey),
-              accountIds = syncData[intervalKey],
-              date = new Date(Date.now() + interval);
+              accountIds = syncData[intervalKey];
 
           // Do not set an timer for a 0 interval, bad things happen.
-          if (!interval)
+          if (!interval) {
             return;
+          }
 
-          alarmMax += 1;
+          taskMax += 1;
 
-          var alarmRequest = mozAlarms.add(date, 'ignoreTimezone',
-                                       makeData(accountIds, interval, date));
-
-          alarmRequest.onsuccess = function() {
-            debug('success: mozAlarms.add for ' + 'IDs: ' + accountIds +
+          navSync.register('interval' + interval, {
+            // minInterval is in seconds.
+            minInterval: interval / 1000,
+            oneShot: false,
+            data: {
+              accountIds: accountIds,
+              interval: interval
+            },
+            wifiOnly: false,
+            // TODO: allow this to be more generic, getting this passed in
+            // from the page using this module. This assumes the current page
+            // without query strings or fragment IDs is the desired entry point.
+            wakeUpPage: location.href.split('?')[0].split('#')[0] })
+          .then(function() {
+            debug('success: navigator.sync.register for ' + 'IDs: ' +
+                  accountIds +
                   ' at ' + interval + 'ms');
             done();
-          };
-
-          alarmRequest.onerror = function(err) {
-            console.error('cronsync-main mozAlarms.add for IDs: ' +
+          }, function(err) {
+            console.error('cronsync-main navigator.sync.register for IDs: ' +
                           accountIds +
                           ' failed: ' + err);
-          };
+          });
         });
 
-        // If no alarms were added, indicate ensureSync is done.
-        if (!alarmMax)
+        // If no sync tasks were added, indicate ensureSync is done.
+        if (!taskMax) {
           done();
-      }.bind(this);
-
-      request.onerror = function(err) {
-        console.error('cronsync-main ensureSync mozAlarms.getAll: error: ' +
-                      err);
-      };
+        }
+      }.bind(this),
+      function(err) {
+        console.error('cronsync-main ensureSync navigator.sync.register: ' +
+                      'error: ' + err);
+      });
     }
   };
 

--- a/test-runner/chrome/content/loggest-chrome-runner.js
+++ b/test-runner/chrome/content/loggest-chrome-runner.js
@@ -35,13 +35,13 @@ Cu.import("resource://gre/modules/osfile.jsm");
 ////////////////////////////////////////////////////////////////////////////////
 // Import important services that b2g's shell.js loads
 //
-// For example, if we want mozAlarms to work, we have to import its service!
+// For example, if we want requestSync to work, we have to import its service!
 // (Commented out stuff was in shell.js but we don't think we need it or
 // absolutely don't want it.)
 Cu.import('resource://gre/modules/ContactService.jsm');
 //Cu.import('resource://gre/modules/SettingsChangeNotifier.jsm');
 Cu.import('resource://gre/modules/DataStoreChangeNotifier.jsm');
-Cu.import('resource://gre/modules/AlarmService.jsm');
+//Cu.import('resource://gre/modules/AlarmService.jsm');
 Cu.import('resource://gre/modules/ActivitiesService.jsm');
 Cu.import('resource://gre/modules/NotificationDB.jsm');
 //Cu.import('resource://gre/modules/Payment.jsm');
@@ -50,6 +50,7 @@ Cu.import("resource://gre/modules/AppsUtils.jsm");
 //Cu.import('resource://gre/modules/Keyboard.jsm');
 //Cu.import('resource://gre/modules/ErrorPage.jsm');
 //Cu.import('resource://gre/modules/AlertsHelper.jsm');
+Cu.import('resource://gre/modules/RequestSyncService.jsm');
 
 Cu.import('resource://gre/modules/Webapps.jsm');
 DOMApplicationRegistry.allAppsLaunchable = true;

--- a/test/manifest.webapp
+++ b/test/manifest.webapp
@@ -8,11 +8,10 @@
     "url": "https://github.com/mozilla-b2g/gaia-email-libs-and-more"
   },
   "messages": [
-    { "alarm": "/index.html" },
-    { "notification": "/index.html" }
+    { "notification": "/index.html" },
+    { "request-sync": "/index.html" }
   ],
   "permissions": {
-    "alarms":{},
     "audio-channel-notification":{},
     "contacts":{ "access": "readcreate" },
     "desktop-notification":{},

--- a/test/unit/resources/th_main.js
+++ b/test/unit/resources/th_main.js
@@ -609,8 +609,8 @@ var TestUniverseMixins = {
    * do_cronsync_releaseOutbox for each account to un-wedge them.  We wedge
    * both of them every time.
    *
-   * We trigger the cronsync by directly poking its onAlarm method.  It has no
-   * cleverness that would defeat this (at this time).
+   * We trigger the cronsync by directly poking its onRequestSync method.  It
+   * has no cleverness that would defeat this (at this time).
    *
    * @param {Object} opts
    * @param {TestAccount[]} accounts
@@ -688,7 +688,7 @@ var TestUniverseMixins = {
 
       var accountIds = [];
 
-      this.eCronSync.expect_alarmFired();
+      this.eCronSync.expect_requestSyncFired();
       this.eCronSync.expect_cronSync_begin();
       this.eCronSync.expect_ensureSync_begin();
       this.eCronSync.expect_syncAccounts_begin();
@@ -710,7 +710,7 @@ var TestUniverseMixins = {
 
       this.expect_apiCronSyncStartReported(accountIds);
 
-      this.universe._cronSync.onAlarm(accountIds);
+      this.universe._cronSync.onRequestSync(accountIds);
     }.bind(this));
   },
 

--- a/test/unit/resources/window_shims.js
+++ b/test/unit/resources/window_shims.js
@@ -161,13 +161,6 @@ var _window_mixin = {
         return req;
       },
     },
-    // By default we start up disabled, so it's not really a biggie either way.
-    mozAlarms: {
-      add: function() {},
-      get: function() {},
-      getAll: function() {},
-      remove: function() {},
-    },
 
     getDeviceStorage: function(ds) {
       return {

--- a/test/unit/test_account_updates.js
+++ b/test/unit/test_account_updates.js
@@ -57,13 +57,17 @@ TD.commonCase('modifyAccount updates should be reflected', function(T, RT) {
 
   T.group('verify the changes took');
   T.check('verify', eLazy, function() {
-    var mailAccount = testUniverse.allAccountsSlice.items[0];
-    var modifyKeys = Object.keys(modifyValues);
-    modifyKeys.forEach(function(key) {
-      var current = mailAccount[key];
-      var modifyTo = modifyValues[key];
-      eLazy.expect_namedValue(key, modifyTo);
-      eLazy.namedValue(key, current);
+    // Ping to make sure modifyAccount work fully completes and notifies out
+    // before testing slice results.
+    testUniverse.MailAPI.ping(function() {
+      var mailAccount = testUniverse.allAccountsSlice.items[0];
+      var modifyKeys = Object.keys(modifyValues);
+      modifyKeys.forEach(function(key) {
+        var current = mailAccount[key];
+        var modifyTo = modifyValues[key];
+        eLazy.expect_namedValue(key, modifyTo);
+        eLazy.namedValue(key, current);
+      });
     });
   });
 

--- a/test/unit/test_cronsync_wait_for_completion.js
+++ b/test/unit/test_cronsync_wait_for_completion.js
@@ -120,7 +120,7 @@ TD.commonCase('cronsync waits for completion', function(T, RT) {
     { top: true, bottom: true, grow: false, newCount: null },
     { syncedToDawnOfTime: true });
 
-  // We are actually running with the real, actual mozAlarms API powering us.
+  // We are actually running with the real, actual sync API powering us.
   // So what we want is a value that is sufficiently far in the future that it
   // won't fire during the test but it's also not ridiculous.  We pick an hour.
   var SYNC_INTERVAL = 60 * 60 * 1000;


### PR DESCRIPTION
Move from mozAlarms to navigator.sync API. The bulk of the changes were just name swaps:

* mozSetMessageHandler: from 'alarm' to 'request-sync'.
* mozAlarm and its DOMRequest style API to navigator.sync's promise API.
* naming local variables with 'alarm' to 'registrations' or a 'sync task', or 'task' in the name.

One bigger difference is that the sync registration can register an ongoing sync task, so we do not need to continually set it. This simplified a check in cronsync-main that also looked a timestamp to make sure the alarm was still valid. Now, the main "ensure" check just makes sure the right intervals are set as sync tasks.

## Upgrade story

How will this work when people upgrade from the alarm to the request-sync code if they currently have sync tasks going?

The syncInterval has been kept in milliseconds to make sure we can continue to use in unaltered, and that value is converted to seconds when talking to the navigator.sync API.

After upgrade, the alarm for the email app should still fire. It will start up the email app, but in normal mode. The ensureSync pathway will then register the sync task, and then periodic syncing will continue on as before. We will just miss one sync interval for that alarm trigger (assuming the normal periodic "let's sync when email is opened does not kick in).

If the user opens the app before the alarm triggers, then the request-sync will get registered, and then the alarm trigger just launches the app unnecessarily once, in the background.

That seemed like a reasonable tradeoff to avoid gumming up the code with both alarm and request-sync pathways that over time would get harder to test and keep maintained.

If the user downgrades to a mozAlarm version, the same sort of switchover would happen.

## cronsync-main.js: wakeUpPage

In an ideal world, I would want the front-end to pass the wakeUpPage to be used, instead of this file assuming the current location is the one desired. For now, I think it is a reasonable choice given the single page web app that email is, and eventually the stage 2 of the request-sync API will use a worker, so that argument should go away, or at least be well-known to our worker if it does need to stay. It helped keep the dependency relationship for cronsync-main very simple by doing the work inside the file.

