### PR TITLE
Bug 1083355 - Fix message sequence number off-by-one ordinal/count error

### DIFF
--- a/js/imap/jobs.js
+++ b/js/imap/jobs.js
@@ -690,7 +690,10 @@ ImapJobDriver.prototype = {
             nextId = targetConn.box.uidNext;
           } else {
             usingUid = false;
-            nextId = targetConn.box.exists;
+            // Message sequence numbers are 1-based, so if 0 exist, then 1 is
+            // the sequence number of the next message.  If 1 exists, its
+            // number is 1, and the next number is 2.  And so on.
+            nextId = targetConn.box.exists + 1;
           }
 
           folderConn._conn.copyMessages(serverIds.join(','),
@@ -744,7 +747,6 @@ ImapJobDriver.prototype = {
                     }
                     var namer = guidToNamer[guid];
                     stateDelta.serverIdMap[namer.suid] = msg.uid;
-                    uidnext = msg.uid + 1;
                     var newSuid = state.moveMap[namer.suid];
                     var newId =
                           parseInt(newSuid.substring(newSuid.lastIndexOf('/') + 1));

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "argparse": "~0.1.15",
     "js-yaml": "~3.2.2",
-    "mail-fakeservers": "0.0.34",
+    "mail-fakeservers": "0.0.35",
     "mozilla-download": "~0.4",
     "ms": "~0.6.2",
     "mustache": "~0.8.2",


### PR DESCRIPTION
We needed to add one to the EXISTS count to be referring to the next allocated
message sequence number.  (UIDNEXT already had these semantics built-in.)

Prior to this fix we would break if there were no messages in the target folder
when falling back to using message sequence numbers.  And in all cases we would
slightly inefficiently get the message-id for at least one extra message that
couldn't possibly be the one we cared about.

I'm also removing a line that was obsoleted in bug 1116694 (which added this
message sequence number path), but was not removed.

I've updated mail-fakeservers to explode if it sees a 0 (or negative) message
sequence number or UID.