### PR TITLE
The variant is stored on the specific tests.

### DIFF
--- a/logic-inspector/js/main.js
+++ b/logic-inspector/js/main.js
@@ -58,7 +58,9 @@ class LogicInspector extends React.Component {
           indexData.some((testRunSummary) => {
             return testRunSummary.suites.some((result) => {
               if (result.filename === this.state.data.filename &&
-                  result.variant === this.state.data.variant) {
+                  result.tests[0] && this.state.data.tests[0] &&
+                  (result.tests[0].variant ===
+                   this.state.data.tests[0].variant)) {
                 latestHref = result.href;
                 return true; // break out!
               }


### PR DESCRIPTION
The logic was accepting the first variant it found for any test type because
it was performing comparisons against properties that didn't exist and
undefined === undefined.  This fix looks at the first test for the summary.
I think this is safe in general because separate variants get separate test
runs and separate JSON files and so all the tests in a file will have the
same variant.  (There just may be multiple tests run in that single file.)

Probably the more correct solution is to include the variant at the location.
But I'm not going to do that tonight, so I'll publish this PR for now,
hopefully not landing this, but maybe landing it and fixing it later.