### PR TITLE
Bug 1160304 - Fix test_storage_upgrade.js ordering

### DIFF
--- a/js/headerCounter.js
+++ b/js/headerCounter.js
@@ -44,11 +44,9 @@ exports.countHeaders = function(storage, filter, options, callback) {
         startUID = lastHeader.id;
     }
 
-
     var checkHandle = function checkHandle(headers) {
-
       // Update the matched count
-      for (i = 0; i < headers.length; i++) {
+      for (var i = 0; i < headers.length; i++) {
         var header = headers[i];
         var isMatch = filter(header);
         if (isMatch) {
@@ -70,7 +68,7 @@ exports.countHeaders = function(storage, filter, options, callback) {
 
       // (otherwise we need to wait for the additional messages to show before
       //  doing anything conclusive)
-    }
+    };
 
     checkHandle(headers);
   }

--- a/test-runner/chrome/content/loggest-chrome-runner.js
+++ b/test-runner/chrome/content/loggest-chrome-runner.js
@@ -1240,7 +1240,6 @@ function DOMLoaded() {
         dump('           (Run "make clean" to delete old test logs.)           \n\n\n');
 
         var testResult = getTestResult(summaries);
-        var jsonString = JSON.stringify({ result: testResult });
 
         var INDEX_FILENAME = 'index.json';
 
@@ -1257,6 +1256,9 @@ function DOMLoaded() {
             });
             return writeFile('test-logs', INDEX_FILENAME,
                              JSON.stringify(jsonIndex));
+          }).then(() => {
+            return writeFile('test-logs', 'last-run.summary',
+                             JSON.stringify({ result: testResult }));
           }).then(() => {
             quitApp();
           });

--- a/test/unit/test_storage_upgrade.js
+++ b/test/unit/test_storage_upgrade.js
@@ -66,6 +66,14 @@ return new LegacyGelamTest('with version 0, upgrade is triggered', function(T) {
                      storage.folderMeta.version);
   });
 
+  T.action('(wait for ping roundtrip to ensure front-end is up-to-date',
+           eSync, ')', function() {
+    eSync.expect('ping');
+    testAccount.MailAPI.ping(function() {
+      eSync.log('ping');
+    });
+  });
+
   T.check('unread counts', eSync, function() {
     testAccount.expect_unread('After upgrade', testFolder, eSync, 7);
   });

--- a/tools/ci/unit/travis.sh
+++ b/tools/ci/unit/travis.sh
@@ -19,9 +19,7 @@ make b2g
 section_echo 'make all-tests'
 make all-tests
 
-TEST_RESULT=`cat ./test-logs/test-run.summary`
-
-if [ `echo $TEST_RESULT | grep -c "success" ` -gt 0 ]
+if [ `grep -c "success" ./test-logs/last-run.summary` -gt 0 ]
 then
   exit 0;
 else


### PR DESCRIPTION
I had already fixed a similar problem for other uses of expect_unread, but this
seemed to have recently been pushed into being a reliable failure.

There was also a missing "var" declaration in a for loop in the logic the test
tests that was not directly involved in this failure, but which is a good idea
to fix.