### PR TITLE
Bug 1145473 - [email/backend] MailAPI's bridge-processing logic may brea...

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -156,7 +156,9 @@
  */
 define(function(require) {
   var evt = require('evt');
-  var equal = require('equal');
+  // Use a relative path here to avoid having consumers need special require
+  // configs (we already specify 'evt' in the frontend).
+  var equal = require('./ext/equal');
 
   /**
    * The `logic` module is callable, as a shorthand for `logic.event()`.
@@ -296,6 +298,7 @@ define(function(require) {
 
   // True when being run within a test.
   logic.underTest = false;
+  logic._currentTestRejectFunction = null;
 
   /**
    * Immediately fail the current test with the given exception. If no test is
@@ -306,7 +309,15 @@ define(function(require) {
    *   Exception object, as with Promise.reject()
    */
   logic.fail = function(ex) {
-    console.error('Not in a test, cannot logic.fail(' + ex + ')');
+    if (logic.underTest) {
+      if (logic._currentTestRejectFunction) {
+        logic._currentTestRejectFunction(ex);
+      } else {
+        throw ex;
+      }
+    } else {
+      console.error('Logic fail:', ex);
+    }
   };
 
 

--- a/js/mailapi.js
+++ b/js/mailapi.js
@@ -5,12 +5,14 @@
 define(
   [
     'exports',
+    './logic',
     // Use a relative link so that consumers do not need to create
     // special config to use main-frame-setup.
     './ext/addressparser'
   ],
   function(
     exports,
+    logic,
     addressparser
   ) {
 
@@ -2062,7 +2064,6 @@ var LEGAL_CONFIG_KEYS = [];
  * help reduce inadvertent breakage later on.
  */
 function reportError() {
-  console.error.apply(console, arguments);
   var msg = null;
   for (var i = 0; i < arguments.length; i++) {
     if (msg)
@@ -2070,7 +2071,8 @@ function reportError() {
     else
       msg = "" + arguments[i];
   }
-  throw new Error(msg);
+  // When in tests, this will fail the test; when not in tests, we just log.
+  logic.fail(new Error(msg));
 }
 var unexpectedBridgeDataError = reportError,
     internalError = reportError,

--- a/test/unit/resources/gelamtest.js
+++ b/test/unit/resources/gelamtest.js
@@ -132,13 +132,10 @@ define(function(require) {
 
           // Run or timeout, which one will win?
           return Promise.race([
-            Promise.resolve(this.fn.call(this, MailAPI)),
             new Promise((resolve, reject) => {
-              logic.fail = (ex) => {
-                dump('*** Logic Fail:\n');
-                reject(ex);
-              };
+              logic._currentTestRejectFunction = reject;
             }),
+            Promise.resolve(this.fn.call(this, MailAPI)),
             new Promise((resolve, reject) => {
               setTimeout(() => {
                 reject(new Error('GelamTest Timeout'));
@@ -152,9 +149,7 @@ define(function(require) {
             this._currentGroupAsyncCallbacks.resolve();
           }
           logic.removeListener('event', handleEvent);
-          logic.fail = function(e) {
-            console.error('Test has ended!', e);
-          };
+          logic._currentTestRejectFunction = null;
           return this.gatherLogs(/* no error! */);
         }).catch((ex) => {
           // Close out the group, noting why it failed.

--- a/test/unit/resources/legacy_gelamtest.js
+++ b/test/unit/resources/legacy_gelamtest.js
@@ -59,7 +59,7 @@
 define(function(require) {
 
   var logic = require('logic');
-  var equal = require('equal');
+  var equal = require('gelam/ext/equal');
   var GelamTest = require('./gelamtest');
 
   var $th_main = require('./th_main'),

--- a/test/unit/test_disaster_recovery.js
+++ b/test/unit/test_disaster_recovery.js
@@ -3,12 +3,33 @@ define(function(require) {
 var GelamTest = require('./resources/gelamtest');
 var AccountHelpers = require('./resources/account_helpers');
 var { backend } = require('./resources/contexts');
+var assert = require('./resources/assert');
 var logic = require('logic');
 
 // XXX: Helpers are gross; see thoughts in account_helpers.js.
 var help;
 
 return [
+  new GelamTest('reportError fails test, does nothing in real life',
+      function*(MailAPI) {
+
+    assert(logic._currentTestRejectFunction, 'reject must be set');
+    var rejected = false;
+    logic._currentTestRejectFunction = function() {
+      rejected = true;
+    }
+
+    // Running in test mode, we should see a rejection.
+    MailAPI._processMessage({ type: 'fakeMessage' });
+    assert(rejected === true, 'should have rejected during test');
+
+    // Running in real life, we should not.
+    rejected = false;
+    logic.underTest = false;
+    MailAPI._processMessage({ type: 'fakeMessage' });
+    assert(rejected === false, 'should not have rejected when not underTest');
+  }),
+
   new GelamTest('Releases mutex during botched sync', function*(MailAPI) {
     this.group('setup');
 


### PR DESCRIPTION
This is the same as the previously-reviewed PR modulo changing `require('equal')` to a relative path to satisfy Gaia.