### PR TITLE
Bug 1169589 - [email/backed] Folder depths are wrong because of mismatched argument call lists and type coercion.

### DIFF
--- a/js/imap/account.js
+++ b/js/imap/account.js
@@ -732,7 +732,7 @@ var properties = {
       });
     }
 
-    walkBoxes(boxesRoot.children, '', 0, null);
+    walkBoxes(boxesRoot.children, 0, null);
 
     // - detect deleted folders
     // track dead folder id's so we can issue a

--- a/js/imap/jobs.js
+++ b/js/imap/jobs.js
@@ -1028,17 +1028,23 @@ ImapJobDriver.prototype = {
 
     var addBoxCallback = function(err, alreadyExists) {
       if (err) {
-        logic(scope, 'createFolderErr', { err: err });
-        // TODO: do something clever in terms of making sure the folder didn't
-        // already exist and the server just doesn't like to provide the
-        // ALREADYEXISTS response.
-        //
-        // For now, give up immediately on the folder for safety.
-        // ensureEssentialFolders is the only logic that creates folders and it
-        // does not know about existing/pending createFolder requests, so it's
-        // for the best if we simply give up permanently on this.
-        done('failure-give-up', null);
-        return;
+        // upgrade error message that contain "already" to mean ALREADYEXISTS.
+        // TODO: make hoodiecrow support ALREADYEXISTS
+        if (err.message && /already/i.test(err.message)) {
+          alreadyExists = true;
+        } else {
+          logic(scope, 'createFolderErr', { err: err });
+          // TODO: do something clever in terms of making sure the folder didn't
+          // already exist and the server just doesn't like to provide the
+          // ALREADYEXISTS response.
+          //
+          // For now, give up immediately on the folder for safety.
+          // ensureEssentialFolders is the only logic that creates folders and it
+          // does not know about existing/pending createFolder requests, so it's
+          // for the best if we simply give up permanently on this.
+          done('failure-give-up', null);
+          return;
+        }
       }
 
       logic(scope, 'createdFolder', { alreadyExists: alreadyExists });

--- a/js/logic.js
+++ b/js/logic.js
@@ -394,7 +394,7 @@ define(function(require) {
           ' to not occur (failIfMatched ' + this.matcher + ').';
       } else {
         return 'MismatchError: expected ' + this.event +
-          ' to match ' + this.matcher + '.';
+          ' to match ' + JSON.stringify(this.matcher.detailPredicate) + '.';
       }
     }}
   });
@@ -425,10 +425,12 @@ define(function(require) {
 
     logic.defineScope(this, 'LogicMatcher');
 
-    var prevPromise = opts.prevPromise || Promise.resolve();
+    var hasPrevPromise = !!opts.prevPromise;
+    var normalizedPrevPromise = opts.prevPromise || Promise.resolve();
 
     if (this.not) {
-      this.promise = prevPromise.then(() => {
+      // XXX this should probably bind instantly like the next case.
+      this.promise = normalizedPrevPromise.then(() => {
         this.capturedLogs.some((event) => {
           if ((!this.ns || event.namespace === this.ns) &&
               event.matches(this.type, this.detailPredicate)) {
@@ -442,6 +444,13 @@ define(function(require) {
         // subscribe to a following match.
         var subscribeToNextMatch = () => {
           var timeoutId = setTimeout(() => {
+            logic(this, 'failedMatch',
+                  {
+                    ns: this.ns,
+                    type: this.type,
+                    detailPredicate: this.detailPredicate,
+                    capturedLogs: this.capturedLogs
+                  });
             reject(new Error('LogicMatcherTimeout: ' + this));
           }, this.timeoutMS);
 
@@ -514,8 +523,8 @@ define(function(require) {
           }
         }
 
-        if (prevPromise) {
-          prevPromise.then(subscribeToNextMatch, (e) => reject(e) );
+        if (hasPrevPromise) {
+          normalizedPrevPromise.then(subscribeToNextMatch, (e) => reject(e) );
         } else {
           try {
             subscribeToNextMatch();
@@ -527,7 +536,7 @@ define(function(require) {
     } else {
       // This is the '.then()' case; we still want to return a
       // LogicMatcher so they can chain, but without any further expectations.
-      this.promise = prevPromise;
+      this.promise = normalizedPrevPromise;
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "argparse": "~0.1.15",
     "js-yaml": "~3.2.2",
-    "mail-fakeservers": "0.0.40",
+    "mail-fakeservers": "0.0.41",
     "mozilla-download": "~1.0.5",
     "ms": "~0.6.2",
     "mustache": "~0.8.2",

--- a/test/test-files.json
+++ b/test/test-files.json
@@ -124,6 +124,10 @@
       "variants": ["imap:fake:no_internaldate_tz"]
     },
 
+    "test_imap_sync_folder_list.js": {
+      "variants": ["imap:fake"]
+    },
+
     "test_incoming_prober.js": {
       "variants": ["imap:noserver", "pop3:noserver"]
     },

--- a/test/unit/resources/account_helpers.js
+++ b/test/unit/resources/account_helpers.js
@@ -243,6 +243,24 @@ AccountHelpers.prototype = {
     return new Promise((resolve) => {
       header.getBody(opts, resolve);
     });
+  },
+
+  /**
+   * S.A.F.E.T.Y. Ping.  Safety Ping.
+   *
+   * This is a hack to ensure that the frontend/test context has received
+   * everything that the backend wanted to send us.  This matters for batching
+   * and things stuck in the double-bounced postmessage bridge.
+   *
+   * This is a reasonable thing to use for v2 stuff, but should be removed from
+   * v3.  Its very existence is a code smell.  Its use?  Code sulfur.
+   */
+  safetyPing() {
+    return new Promise((resolve) => {
+      this.MailAPI.ping(() => {
+        resolve();
+      });
+    });
   }
 };
 

--- a/test/unit/resources/contexts.js
+++ b/test/unit/resources/contexts.js
@@ -50,7 +50,8 @@ define(function(require) {
                    null),
             account: null, // set up later
             controlServerBaseUrl: opts.controlServerBaseUrl,
-            imapExtensions: opts.imapExtensions || opts.imapExtensions,
+            imapExtensions: opts.imapExtensions,
+            folderConfig: opts.folderConfig,
             smtpExtensions: opts.smtpExtensions,
             deliveryMode: opts.deliveryMode,
             oauth: opts.oauth,

--- a/test/unit/resources/gelamtest.js
+++ b/test/unit/resources/gelamtest.js
@@ -18,7 +18,10 @@ define(function(require) {
    * @param {string} name
    *   Human-readable test name.
    * @param {object} [options]
-   *   Optional. Currently no public options are supported.
+   *   Stuff!  So much stuff!
+   * @param {FolderConfig} [options.folderConfig]
+   *   The "folderConfig" is directly passed-through to the fake-server when it
+   *   is initialized.  Currently only the imapd.js fake-server supports this.
    * @param {function(MailAPI)} fn
    *   Test function. Accepts the MailAPI instance as the first parameter.
    *   Should return a Promise with the result of your test.

--- a/test/unit/resources/servers.js
+++ b/test/unit/resources/servers.js
@@ -48,7 +48,7 @@ define((require) => {
       },
       options: {
         imapExtensions: options.imapExtensions,
-        folderConfig: options.folderConfig || null,
+        folderConfig: options.folderConfig,
         useTimezoneMins: this.timezoneMins,
         smtpExtensions: options.smtpExtensions,
         oauth: options.oauth

--- a/test/unit/resources/th_fake_servers.js
+++ b/test/unit/resources/th_fake_servers.js
@@ -17,6 +17,7 @@ define((require, exports) => {
         account: null, // set up later
         controlServerBaseUrl: TEST_PARAMS.controlServerBaseUrl,
         imapExtensions: opts.imapExtensions || TEST_PARAMS.imapExtensions,
+        folderConfig: opts.folderConfig,
         smtpExtensions: opts.smtpExtensions,
         deliveryMode: opts.deliveryMode,
         oauth: opts.oauth,

--- a/test/unit/test_imap_create_folders.js
+++ b/test/unit/test_imap_create_folders.js
@@ -1,9 +1,6 @@
 /**
- * Ensure that if we connect to an IMAP server without Sent or Trash folders
- * that we will try and create them and succeed in creating them.
- *
- * This can only be done on a fake server.
- **/
+ * Tests of IMAP-specific folder logic.
+ */
 
 define(function(require) {
 
@@ -12,9 +9,11 @@ var $th_main = require('./resources/th_main');
 var deriveFolderPath = require('imap/jobs').deriveFolderPath;
 
 /**
- * Test the folder
+ * Tests the implementation of deriveFolderPath which is used in folder
+ * creation.
  */
-return new LegacyGelamTest('folder path logic', function(T, RT) {
+return [
+new LegacyGelamTest('folder path logic', function(T, RT) {
   $th_main.thunkConsoleForNonTestUniverse();
   var eCheck = T.lazyLogger('check');
 
@@ -166,9 +165,16 @@ return new LegacyGelamTest('folder path logic', function(T, RT) {
       eCheck.log('result', result, check);
     });
   });
-});
+}),
 
-TD.commonCase('create Sent and Trash folders when missing', function(T, RT) {
+/**
+ * Ensure that if we connect to an IMAP server without Sent or Trash folders
+ * that we will try and create them and succeed in creating them.
+ *
+ * This can only be done on a fake server.
+ */
+new LegacyGelamTest('create Sent and Trash folders when missing',
+                    function(T, RT) {
   T.group('setup');
 
   var testUniverse = T.actor('TestUniverse', 'U');
@@ -205,7 +211,7 @@ TD.commonCase('create Sent and Trash folders when missing', function(T, RT) {
       }
     });
   var eCheck = T.lazyLogger('check');
-  var eJobs = new T.actor('ImapJobDriver');
+  var eJobs = T.actor('ImapJobDriver');
 
   // hold onto this between steps so we can test object identity
   var backendSent;
@@ -285,6 +291,5 @@ TD.commonCase('create Sent and Trash folders when missing', function(T, RT) {
   });
 
   T.group('cleanup');
-});
-
+})];
 });

--- a/test/unit/test_imap_sync_folder_list.js
+++ b/test/unit/test_imap_sync_folder_list.js
@@ -1,0 +1,118 @@
+define(function(require) {
+
+var GelamTest = require('./resources/gelamtest');
+var logic = require('logic');
+var AccountHelpers = require('./resources/account_helpers');
+var assert = require('./resources/assert');
+
+/**
+ * The list of input and output folder trees.  The output trees are currently
+ * in the expected sorted order from the folders slice, although I'm not 100%
+ * sure that it's a good idea to be baking that in here too.
+ *
+ * TODO: Add a lot more cases here.  For now I'm just adding enough for the
+ * depth calculation regression in bug 1169589.
+ */
+var treeDefs = [
+  {
+    name: 'non-namespaced, non-special-use, all folders already exist',
+    folderConfig: {
+      underInbox: false,  // (this is what makes us non-namespaced)
+      folders: [
+        { name: 'Drafts' },
+        { name: 'Sent' },
+        { name: 'Trash' },
+        { name: 'foo' },
+        { name: 'foo/bar' },
+        { name: 'foo/bar/baz' }
+      ]
+    },
+    expectedFolders: [
+      { name: 'INBOX', path: 'INBOX', type: 'inbox', depth: 0 },
+      { name: 'Drafts', path: 'Drafts', type: 'drafts', depth: 0 },
+      { name: 'localdrafts', path: 'localdrafts', type: 'localdrafts',
+        depth: 0 },
+      { name: 'outbox', path: 'outbox', type: 'outbox', depth: 0 },
+      { name: 'Sent', path: 'Sent', type: 'sent', depth: 0 },
+      { name: 'Trash', path: 'Trash', type: 'trash', depth: 0 },
+      { name: 'foo', path: 'foo', type: 'normal', depth: 0 },
+      { name: 'bar', path: 'foo/bar', type: 'normal', depth: 1 },
+      { name: 'baz', path: 'foo/bar/baz', type: 'normal', depth: 2 }
+    ],
+  }
+];
+
+
+/**
+ * Create a test that verifies the folder hierarchy resulting from the initial
+ * syncFolderList call is as expected.  It also verifies that the folder
+ * hierarchy remains the same after invoking syncFolderList a second time.
+ *
+ * We are endeavoring to verify the following things:
+ * - Types are correctly inferred.
+ * - Missing critical folders ("sent" and "trash") are automatically created.
+ * - The offline/local-only "localdrafts" and "outbox" folders are created at
+ *   their expected locations (given the configuration of the folder tree.)
+ * - depth is correct (we regressed this once)
+ *
+ * This test moots some aspects of the legacy tests in the following files, but
+ * they cannot yet be removed because of edge-cases we do not cover.  (And we
+ * should not cover, because this test already verifies a lot.  But I believe it
+ * does make sense that we define input and output folder trees and the high
+ * level things we expect to be logged during the process of normalization.)
+ * Also, we don't have enough treeDefs up above.
+ * - test_account_folder_logic.js
+ * - test_imap_create_folder.js
+ */
+function makeTestForFolderTree(treeDef) {
+  return new GelamTest(
+    'syncFolderList: ' + treeDef.name,
+    {
+      folderConfig: treeDef.folderConfig
+    },
+    function*(MailAPI) {
+      this.group('setup');
+
+      var help = new AccountHelpers(MailAPI);
+
+      // start expecting syncFolderList (It happens as a side effect of the
+      // account being created, so we need to start watching before we start
+      // creating the account.)
+      // XXX note that this is a backend worker-thread task, so really this
+      // should be done using the backend context somehow.  Maybe the context
+      // should expose a match function?  Or are we just acting as if the
+      // test context can see all log events in a unified manner?  (Seems
+      // reasonable enough, but there are ordering concerns, at least
+      var matchSyncFolderList = logic
+        .match('Account', 'runOp', { mode: 'do', type: 'syncFolderList' });
+
+      var account = yield help.createAccount(this.options);
+
+      // wait for the runOp to complete
+      yield matchSyncFolderList;
+
+      // make sure we hear everything
+      yield help.safetyPing();
+
+      var folderScope = {};
+      logic.defineScope(folderScope, 'ExpectedFolders');
+
+      // chain up our expectations
+      var folderMatcher = logic;
+      treeDef.expectedFolders.forEach(function(expFolder) {
+        folderMatcher =
+          folderMatcher.match('ExpectedFolders', 'folder', expFolder);
+      });
+
+      help.folders.items.forEach(function(folder) {
+        logic(folderScope, 'folder',
+              { name: folder.name, path: folder.path, type: folder.type,
+                depth: folder.depth });
+      });
+
+      yield folderMatcher;
+    });
+}
+
+return treeDefs.map(makeTestForFolderTree);
+});


### PR DESCRIPTION
- Implements "folderConfig" support for hoodiecrow, which we had previously
  punted on.  See the speculatively landed/released 0.41 at:
  https://github.com/mozilla-b2g/mail-fakeservers/pull/33

- Updates test_imap_create_folders.js (which was where I introduced
  folderConfig) to be run now.  I did a minor hack enhancement where if we
  get a "NO" to our createFolder command and the message includes "already"
  that we treat it like we got an ALREADYEXISTS.  This was important because
  imapd would say ALREADYEXISTS (after my changes? before?) but hoodiecrow
  does not yet do this.

- Fixes a bug in logic.js where we wouldn't start listening for events until
  a future turn of the event loop.  (If this seems familiar, I'd raised a
  point on this and you'd reworked the code to avoid the problem, but the
  normalization with a "|| Promise.resolve()" at the top defeated a check
  further down.  I've punted on the "not" case because I like keeping future
  me on his toes.

- Improves the logic.js logging for the debugging scenario by:
  - logging failed matches on timeout as a proper event
  - JSON stringifying the expectation on mis-match.  This probably would be
    better as a full event, but this change is a big improvement over seeing
    "[object Object]".

- Adds a new non-legacy test (using folderConfig) that fails without the fix
  and succeeds with it.

- The fix for the depth bug.