### PR TITLE
Bug 1206156 - [email] Make requestGrowth not throw on misuse to avoid breaking vscroll state machine

### DIFF
--- a/js/mailapi.js
+++ b/js/mailapi.js
@@ -25,6 +25,27 @@ function objCopy(obj) {
 }
 
 /**
+ * Error reporting helper; we will probably eventually want different behaviours
+ * under development, under unit test, when in use by QA, advanced users, and
+ * normal users, respectively.  By funneling all errors through one spot, we
+ * help reduce inadvertent breakage later on.
+ */
+function reportError() {
+  var msg = null;
+  for (var i = 0; i < arguments.length; i++) {
+    if (msg)
+      msg += " " + arguments[i];
+    else
+      msg = "" + arguments[i];
+  }
+  // When in tests, this will fail the test; when not in tests, we just log.
+  logic.fail(new Error(msg));
+}
+var unexpectedBridgeDataError = reportError,
+    internalError = reportError,
+    reportClientCodeError = reportError;
+
+/**
  * The number of header wire messages to cache in the recvCache
  */
 var HEADER_CACHE_LIMIT = 8;
@@ -1696,8 +1717,10 @@ BridgedViewSlice.prototype = {
    * some potentially costly growth of the data set should be performed.
    */
   requestGrowth: function(dirMagnitude, userRequestsGrowth) {
-    if (this._growing)
-      throw new Error('Already growing in ' + this._growing + ' dir.');
+    if (this._growing) {
+      reportError('Already growing in ' + this._growing + ' dir.');
+      return;
+    }
     this._growing = dirMagnitude;
     this.pendingRequestCount++;
 
@@ -2056,28 +2079,6 @@ MessageComposition.prototype = {
 };
 
 var LEGAL_CONFIG_KEYS = [];
-
-/**
- * Error reporting helper; we will probably eventually want different behaviours
- * under development, under unit test, when in use by QA, advanced users, and
- * normal users, respectively.  By funneling all errors through one spot, we
- * help reduce inadvertent breakage later on.
- */
-function reportError() {
-  var msg = null;
-  for (var i = 0; i < arguments.length; i++) {
-    if (msg)
-      msg += " " + arguments[i];
-    else
-      msg = "" + arguments[i];
-  }
-  // When in tests, this will fail the test; when not in tests, we just log.
-  logic.fail(new Error(msg));
-}
-var unexpectedBridgeDataError = reportError,
-    internalError = reportError,
-    reportClientCodeError = reportError;
-
 
 // Common idioms:
 //


### PR DESCRIPTION
I moved reportError and friends up because, although eslint was totally losing its composure over all the lint errors, it had a point about me using it before it was defined.