### PR TITLE
Bug 1219853 - [email] Go back to mozAlarms instead of request-sync

### DIFF
--- a/js/main-frame-setup.js
+++ b/js/main-frame-setup.js
@@ -5,7 +5,7 @@
  * Main: Spawns worker
  * Worker: Loads core JS
  * Worker: 'hello' => main
- * Main: 'hello' => worker with online status and navigator.sync status
+ * Main: 'hello' => worker with online status and mozAlarms status
  * Worker: Creates MailUniverse
  * Worker 'mailbridge'.'hello' => main
  * Main: Creates MailAPI, sends event to UI

--- a/js/worker-support/cronsync-main.js
+++ b/js/worker-support/cronsync-main.js
@@ -9,6 +9,15 @@ define(function(require) {
     console.log('cronsync-main: ' + str);
   }
 
+  function makeData(accountIds, interval, date) {
+    return {
+      type: 'sync',
+      accountIds: accountIds,
+      interval: interval,
+      timestamp: date.getTime()
+    };
+  }
+
   // Creates a string key from an array of string IDs. Uses a space
   // separator since that cannot show up in an ID.
   function makeAccountKey(accountIds) {
@@ -62,163 +71,175 @@ define(function(require) {
     },
 
     /**
-     * Clears all sync-based tasks. Normally not called, except perhaps for
+     * Clears all sync-based alarms. Normally not called, except perhaps for
      * tests or debugging.
      */
     clearAll: function() {
-      var navSync = navigator.sync;
-      if (!navSync) {
+      var mozAlarms = navigator.mozAlarms;
+      if (!mozAlarms) {
         return;
       }
 
-      navSync.registrations().then(function(registrations) {
-        if (!registrations.length) {
+      var r = mozAlarms.getAll();
+
+      r.onsuccess = function(event) {
+        var alarms = event.target.result;
+        if (!alarms) {
           return;
         }
 
-        registrations.forEach(function(registeredTask) {
-          navSync.unregister(registeredTask.task);
+        alarms.forEach(function(alarm) {
+          if (alarm.data && alarm.data.type === 'sync') {
+            mozAlarms.remove(alarm.id);
+          }
         });
-      }.bind(this),
-      function(err) {
-        console.error('cronsync-main clearAll navigator.sync.registrations ' +
-                      'error: ' + err);
-      }.bind(this));
+      }.bind(this);
+      r.onerror = function(err) {
+        console.error('cronsync-main clearAll mozAlarms.getAll: error: ' +
+                      err);
+      }.bind(this);
     },
 
     /**
-     * Makes sure there is an sync task set for every account in
-     * the list.
-     * @param  {Object} syncData. An object with keys that are
-     * 'interval' + intervalInMilliseconds, and values are arrays
-     * of account IDs that should be synced at that interval.
+     * Makes sure there is an alarm set for every account in the list.
+     * @param  {Object} syncData. An object with keys that are 'interval' +
+     * intervalInMilliseconds, and values are arrays of account IDs that should
+     * be synced at that interval.
      */
     ensureSync: function (syncData) {
-      var navSync = navigator.sync;
-      if (!navSync) {
-        console.warn('no navigator.sync support!');
-        // Let backend know work has finished, even though it was a no-op.
-        this._sendMessage('syncEnsured');
+
+      var mozAlarms = navigator.mozAlarms;
+      if (!mozAlarms) {
+        console.warn('no mozAlarms support!');
         return;
       }
 
       debug('ensureSync called');
 
-      navSync.registrations().then(function(registrations) {
+      var request = mozAlarms.getAll();
+
+      request.onsuccess = function(event) {
         debug('success!');
 
-        // Find all IDs being tracked by sync tasks
-        var expiredTasks = [],
-            okTaskIntervals = {},
-            uniqueTasks = {};
+        var alarms = event.target.result;
+        // If there are no alarms a falsey value may be returned.  We want
+        // to not die and also make sure to signal we completed, so just make
+        // an empty list.
+        if (!alarms) {
+          alarms = [];
+        }
 
-        registrations.forEach(function(task) {
-          // minInterval in seconds, but use milliseconds for sync values
-          // internally.
-          var intervalKey = 'interval' + (task.minInterval * 1000),
+        // Find all IDs being tracked by alarms
+        var expiredAlarmIds = [],
+            okAlarmIntervals = {},
+            uniqueAlarms = {};
+
+        alarms.forEach(function(alarm) {
+          // Only care about sync alarms.
+          if (!alarm.data || !alarm.data.type || alarm.data.type !== 'sync') {
+            return;
+          }
+
+          var intervalKey = 'interval' + alarm.data.interval,
               wantedAccountIds = syncData[intervalKey];
 
           if (!wantedAccountIds || !hasSameValues(wantedAccountIds,
-                                                  task.data.accountIds)) {
-            debug('account array mismatch, canceling existing sync task');
-            expiredTasks.push(task);
+                                                  alarm.data.accountIds)) {
+            debug('account array mismatch, canceling existing alarm');
+            expiredAlarmIds.push(alarm.id);
           } else {
-            // Confirm the existing sync task is still good.
+            // Confirm the existing alarm is still good.
             var interval = toInterval(intervalKey),
+                now = Date.now(),
+                alarmTime = alarm.data.timestamp,
                 accountKey = makeAccountKey(wantedAccountIds);
 
-            // If the interval is nonzero, and there is no other task found
+            // If the interval is nonzero, and there is no other alarm found
             // for that account combo, and if it is not in the past and if it
             // is not too far in the future, it is OK to keep.
-            if (interval && !uniqueTasks.hasOwnProperty(accountKey)) {
-              debug('existing sync task is OK: ' + interval);
-              uniqueTasks[accountKey] = true;
-              okTaskIntervals[intervalKey] = true;
+            if (interval && !uniqueAlarms.hasOwnProperty(accountKey) &&
+                alarmTime > now && alarmTime < now + interval) {
+              debug('existing alarm is OK: ' + accountKey);
+              uniqueAlarms[accountKey] = true;
+              okAlarmIntervals[intervalKey] = true;
             } else {
-              debug('existing sync task is out of interval range, canceling');
-              expiredTasks.push(task);
+              debug('existing alarm is out of interval range, canceling');
+              expiredAlarmIds.push(alarm.id);
             }
           }
         });
 
-        expiredTasks.forEach(function(expiredTask) {
-          navSync.unregister(expiredTask.task);
+        expiredAlarmIds.forEach(function(alarmId) {
+          mozAlarms.remove(alarmId);
         });
 
-        var taskMax = 0,
-            taskCount = 0,
+        var alarmMax = 0,
+            alarmCount = 0,
             self = this;
 
-        // Called when sync tasks are confirmed to be set.
+        // Called when alarms are confirmed to be set.
         function done() {
-          taskCount += 1;
-          if (taskCount < taskMax) {
+          alarmCount += 1;
+          if (alarmCount < alarmMax) {
             return;
           }
 
           debug('ensureSync completed');
           // Indicate ensureSync has completed because the
-          // back end is waiting to hear sync task was set
-          // before triggering sync complete.
+          // back end is waiting to hear alarm was set before
+          // triggering sync complete.
           self._sendMessage('syncEnsured');
         }
 
         Object.keys(syncData).forEach(function(intervalKey) {
-          // Skip if the existing sync task is already good.
-          if (okTaskIntervals.hasOwnProperty(intervalKey)) {
+          // Skip if the existing alarm is already good.
+          if (okAlarmIntervals.hasOwnProperty(intervalKey)) {
             return;
           }
 
           var interval = toInterval(intervalKey),
-              accountIds = syncData[intervalKey];
+              accountIds = syncData[intervalKey],
+              date = new Date(Date.now() + interval);
 
           // Do not set an timer for a 0 interval, bad things happen.
           if (!interval) {
             return;
           }
 
-          taskMax += 1;
+          alarmMax += 1;
 
-          navSync.register('interval' + interval, {
-            // minInterval is in seconds.
-            minInterval: interval / 1000,
-            oneShot: false,
-            data: {
-              accountIds: accountIds,
-              interval: interval
-            },
-            wifiOnly: false,
-            // TODO: allow this to be more generic, getting this passed in
-            // from the page using this module. This assumes the current page
-            // without query strings or fragment IDs is the desired entry point.
-            wakeUpPage: location.href.split('?')[0].split('#')[0] })
-          .then(function() {
-            debug('success: navigator.sync.register for ' + 'IDs: ' +
-                  accountIds +
+          var alarmRequest = mozAlarms.add(date, 'ignoreTimezone',
+                                       makeData(accountIds, interval, date));
+
+          alarmRequest.onsuccess = function() {
+            debug('success: mozAlarms.add for ' + 'IDs: ' + accountIds +
                   ' at ' + interval + 'ms');
             done();
-          }, function(err) {
-            console.error('cronsync-main navigator.sync.register for IDs: ' +
+          };
+
+          alarmRequest.onerror = function(err) {
+            console.error('cronsync-main mozAlarms.add for IDs: ' +
                           accountIds +
                           ' failed: ' + err);
-          });
+          };
         });
 
-        // If no sync tasks were added, indicate ensureSync is done.
-        if (!taskMax) {
+        // If no alarms were added, indicate ensureSync is done.
+        if (!alarmMax) {
           done();
         }
-      }.bind(this),
-      function(err) {
-        console.error('cronsync-main ensureSync navigator.sync.register: ' +
-                      'error: ' + err);
-      });
+      }.bind(this);
+
+      request.onerror = function(err) {
+        console.error('cronsync-main ensureSync mozAlarms.getAll: error: ' +
+                      err);
+      };
     }
   };
 
   if (navigator.mozSetMessageHandler) {
-    navigator.mozSetMessageHandler('request-sync', function onRequestSync(e) {
-      console.log('mozSetMessageHandler: received a request-sync');
+    navigator.mozSetMessageHandler('alarm', function onAlarm(alarm) {
+      console.log('mozSetMessageHandler: received an alarm');
 
       // Important for gaia email app to know when a mozSetMessageHandler has
       // been dispatched. Could be removed if notification close events did not
@@ -229,7 +250,11 @@ define(function(require) {
         window.appDispatchedMessage = true;
       }
 
-      var data = e.data;
+      // Do not bother with alarms that are not sync alarms.
+      var data = alarm.data;
+      if (!data || data.type !== 'sync') {
+        return;
+      }
 
       // Need to acquire the wake locks during this notification
       // turn of the event loop -- later turns are not guaranteed to
@@ -253,9 +278,9 @@ define(function(require) {
                              makeAccountKey(data.accountIds), locks);
       }
 
-      debug('request-sync started at ' + (new Date()));
+      debug('alarm dispatch started at ' + (new Date()));
 
-      dispatcher._sendMessage('requestSync',
+      dispatcher._sendMessage('alarm',
                               [data.accountIds, data.interval]);
     });
   }

--- a/test-runner/chrome/content/loggest-chrome-runner.js
+++ b/test-runner/chrome/content/loggest-chrome-runner.js
@@ -35,13 +35,13 @@ Cu.import("resource://gre/modules/osfile.jsm");
 ////////////////////////////////////////////////////////////////////////////////
 // Import important services that b2g's shell.js loads
 //
-// For example, if we want requestSync to work, we have to import its service!
+// For example, if we want mozAlarms to work, we have to import its service!
 // (Commented out stuff was in shell.js but we don't think we need it or
 // absolutely don't want it.)
 Cu.import('resource://gre/modules/ContactService.jsm');
 //Cu.import('resource://gre/modules/SettingsChangeNotifier.jsm');
 Cu.import('resource://gre/modules/DataStoreChangeNotifier.jsm');
-//Cu.import('resource://gre/modules/AlarmService.jsm');
+Cu.import('resource://gre/modules/AlarmService.jsm');
 Cu.import('resource://gre/modules/ActivitiesService.jsm');
 Cu.import('resource://gre/modules/NotificationDB.jsm');
 //Cu.import('resource://gre/modules/Payment.jsm');
@@ -50,7 +50,6 @@ Cu.import("resource://gre/modules/AppsUtils.jsm");
 //Cu.import('resource://gre/modules/Keyboard.jsm');
 //Cu.import('resource://gre/modules/ErrorPage.jsm');
 //Cu.import('resource://gre/modules/AlertsHelper.jsm');
-Cu.import('resource://gre/modules/RequestSyncService.jsm');
 
 Cu.import('resource://gre/modules/Webapps.jsm');
 DOMApplicationRegistry.allAppsLaunchable = true;

--- a/test/manifest.webapp
+++ b/test/manifest.webapp
@@ -8,10 +8,11 @@
     "url": "https://github.com/mozilla-b2g/gaia-email-libs-and-more"
   },
   "messages": [
-    { "notification": "/index.html" },
-    { "request-sync": "/index.html" }
+    { "alarm": "/index.html" },
+    { "notification": "/index.html" }
   ],
   "permissions": {
+    "alarms":{},
     "audio-channel-notification":{},
     "contacts":{ "access": "readcreate" },
     "desktop-notification":{},

--- a/test/unit/resources/th_main.js
+++ b/test/unit/resources/th_main.js
@@ -597,7 +597,7 @@ var TestUniverseMixins = {
    * do_cronsync_releaseOutbox for each account to un-wedge them.  We wedge
    * both of them every time.
    *
-   * We trigger the cronsync by directly poking its onRequestSync method.  It
+   * We trigger the cronsync by directly poking its onAlarm method.  It
    * has no cleverness that would defeat this (at this time).
    *
    * @param {Object} opts
@@ -679,7 +679,7 @@ var TestUniverseMixins = {
 
       var accountIds = [];
 
-      this.eCronSync.expect('requestSyncFired');
+      this.eCronSync.expect('alarmFired');
       this.eCronSync.expect('cronSync_begin');
       this.eCronSync.expect('ensureSync_begin');
       this.eCronSync.expect('syncAccounts_begin');
@@ -705,7 +705,7 @@ var TestUniverseMixins = {
 
       this.expect('apiCronSyncStartReported', { ids: accountIds });
 
-      this.universe._cronSync.onRequestSync(accountIds);
+      this.universe._cronSync.onAlarm(accountIds);
     }.bind(this));
   },
 

--- a/test/unit/resources/window_shims.js
+++ b/test/unit/resources/window_shims.js
@@ -162,6 +162,14 @@ var _window_mixin = {
       },
     },
 
+    // By default we start up disabled, so it's not really a biggie either way.
+    mozAlarms: {
+      add: function() {},
+      get: function() {},
+      getAll: function() {},
+      remove: function() {},
+    },
+
     getDeviceStorage: function(ds) {
       return {
         addNamed: function(blob, name) {

--- a/test/unit/test_cronsync_wait_for_completion.js
+++ b/test/unit/test_cronsync_wait_for_completion.js
@@ -116,7 +116,7 @@ return new LegacyGelamTest('cronsync waits for completion', function(T, RT) {
     { top: true, bottom: true, grow: false, newCount: null },
     { syncedToDawnOfTime: true });
 
-  // We are actually running with the real, actual sync API powering us.
+  // We are actually running with the real, actual mozAlarms API powering us.
   // So what we want is a value that is sufficiently far in the future that it
   // won't fire during the test but it's also not ridiculous.  We pick an hour.
   var SYNC_INTERVAL = 60 * 60 * 1000;


### PR DESCRIPTION
This is like a reversion of [bug 1098289](https://bugzilla.mozilla.org/show_bug.cgi?id=1098289). I ran the tests and I did see some failures, but they were related to composition, so I think it is the separate error you mentioned in a meeting yesterday.